### PR TITLE
Add compatibility with Mac OS X and the BSDs

### DIFF
--- a/squashfs-tools/action.c
+++ b/squashfs-tools/action.c
@@ -39,6 +39,10 @@
 #include <limits.h>
 #include <errno.h>
 
+#ifndef FNM_EXTMATCH /* glibc extension */
+    #define FNM_EXTMATCH 0
+#endif
+
 #include "squashfs_fs.h"
 #include "mksquashfs.h"
 #include "action.h"

--- a/squashfs-tools/action.c
+++ b/squashfs-tools/action.c
@@ -1957,9 +1957,12 @@ static char *get_start(char *s, int n)
 
 static int subpathname_fn(struct atom *atom, struct action_data *action_data)
 {
-	return fnmatch(atom->argv[0], get_start(strdupa(action_data->subpath),
+	char *path = strdup(action_data->subpath);
+	int is_match = fnmatch(atom->argv[0], get_start(path,
 		count_components(atom->argv[0])),
 		FNM_PATHNAME|FNM_PERIOD|FNM_EXTMATCH) == 0;
+	free(path);
+	return is_match;
 }
 
 TEST_VAR_FN(filesize, ACTION_REG, action_data->buf->st_size)

--- a/squashfs-tools/info.c
+++ b/squashfs-tools/info.c
@@ -134,31 +134,22 @@ void dump_state()
 void *info_thrd(void *arg)
 {
 	sigset_t sigmask;
-	struct timespec timespec = { .tv_sec = 1, .tv_nsec = 0 };
-	int sig, waiting = 0;
+	int sig, err, waiting = 0;
 
 	sigemptyset(&sigmask);
 	sigaddset(&sigmask, SIGQUIT);
 	sigaddset(&sigmask, SIGHUP);
+	sigaddset(&sigmask, SIGALRM);
 
 	while(1) {
-		if(waiting)
-			sig = sigtimedwait(&sigmask, NULL, &timespec);
-		else
-			sig = sigwaitinfo(&sigmask, NULL);
+		err = sigwait(&sigmask, &sig);
 
-		if(sig == -1) {
+		if(err == -1) {
 			switch(errno) {
-			case EAGAIN:
-				/* interval timed out */
-				waiting = 0;
-				/* FALLTHROUGH */
 			case EINTR:
-				/* if waiting, the wait will be longer, but
-				   that's OK */
 				continue;
 			default:
-				BAD_ERROR("sigtimedwait/sigwaitinfo failed "
+				BAD_ERROR("sigwait failed "
 					"because %s\n", strerror(errno));
 			}
 		}
@@ -169,8 +160,12 @@ void *info_thrd(void *arg)
 			/* set one second interval period, if ^\ received
 			   within then, dump queue and cache status */
 			waiting = 1;
-		} else
+			alarm(1);
+		} else if (sig == SIGQUIT) {
 			dump_state();
+		} else if (sig == SIGALRM) {
+			waiting = 0;
+		}
 	}
 }
 

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -4094,6 +4094,7 @@ void initialise_threads(int readq, int fragq, int bwriteq, int fwriteq,
 	sigemptyset(&sigmask);
 	sigaddset(&sigmask, SIGQUIT);
 	sigaddset(&sigmask, SIGHUP);
+	sigaddset(&sigmask, SIGALRM);
 	if(pthread_sigmask(SIG_BLOCK, &sigmask, NULL) == -1)
 		BAD_ERROR("Failed to set signal mask in intialise_threads\n");
 

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -828,13 +828,13 @@ char *subpathname(struct dir_ent *dir_ent)
 }
 
 
-inline unsigned int get_inode_no(struct inode_info *inode)
+static inline unsigned int get_inode_no(struct inode_info *inode)
 {
 	return inode->inode_number;
 }
 
 
-inline unsigned int get_parent_no(struct dir_info *dir)
+static inline unsigned int get_parent_no(struct dir_info *dir)
 {
 	return dir->depth ? get_inode_no(dir->dir_ent->inode) : inode_no;
 }
@@ -2057,7 +2057,7 @@ struct file_info *duplicate(long long file_size, long long bytes,
 }
 
 
-inline int is_fragment(struct inode_info *inode)
+static inline int is_fragment(struct inode_info *inode)
 {
 	int file_size = inode->buf.st_size;
 
@@ -3020,20 +3020,20 @@ struct inode_info *lookup_inode2(struct stat *buf, int pseudo, int id)
 }
 
 
-inline struct inode_info *lookup_inode(struct stat *buf)
+static inline struct inode_info *lookup_inode(struct stat *buf)
 {
 	return lookup_inode2(buf, 0, 0);
 }
 
 
-inline void alloc_inode_no(struct inode_info *inode, unsigned int use_this)
+static inline void alloc_inode_no(struct inode_info *inode, unsigned int use_this)
 {
 	if (inode->inode_number == 0)
 		inode->inode_number = use_this ? : inode_no ++;
 }
 
 
-inline struct dir_ent *create_dir_entry(char *name, char *source_name,
+static inline struct dir_ent *create_dir_entry(char *name, char *source_name,
 	char *nonstandard_pathname, struct dir_info *dir)
 {
 	struct dir_ent *dir_ent = malloc(sizeof(struct dir_ent));
@@ -3050,7 +3050,7 @@ inline struct dir_ent *create_dir_entry(char *name, char *source_name,
 }
 
 
-inline void add_dir_entry(struct dir_ent *dir_ent, struct dir_info *sub_dir,
+static inline void add_dir_entry(struct dir_ent *dir_ent, struct dir_info *sub_dir,
 	struct inode_info *inode_info)
 {
 	struct dir_info *dir = dir_ent->our_dir;
@@ -3066,7 +3066,7 @@ inline void add_dir_entry(struct dir_ent *dir_ent, struct dir_info *sub_dir,
 }
 
 
-inline void add_dir_entry2(char *name, char *source_name,
+static inline void add_dir_entry2(char *name, char *source_name,
 	char *nonstandard_pathname, struct dir_info *sub_dir,
 	struct inode_info *inode_info, struct dir_info *dir)
 {
@@ -3078,7 +3078,7 @@ inline void add_dir_entry2(char *name, char *source_name,
 }
 
 
-inline void free_dir_entry(struct dir_ent *dir_ent)
+static inline void free_dir_entry(struct dir_ent *dir_ent)
 {
 	if(dir_ent->name)
 		free(dir_ent->name);
@@ -3090,7 +3090,7 @@ inline void free_dir_entry(struct dir_ent *dir_ent)
 }
 
 
-inline void add_excluded(struct dir_info *dir)
+static inline void add_excluded(struct dir_info *dir)
 {
 	dir->excluded ++;
 }

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -51,6 +51,10 @@
 #include <limits.h>
 #include <ctype.h>
 
+#ifndef FNM_EXTMATCH /* glibc extension */
+    #define FNM_EXTMATCH 0
+#endif
+
 #ifndef linux
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN

--- a/squashfs-tools/mksquashfs.h
+++ b/squashfs-tools/mksquashfs.h
@@ -24,6 +24,7 @@
  * mksquashfs.h
  *
  */
+#include <pthread.h>
 
 struct dir_info {
 	char			*pathname;

--- a/squashfs-tools/pseudo.c
+++ b/squashfs-tools/pseudo.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <ctype.h>

--- a/squashfs-tools/read_xattrs.c
+++ b/squashfs-tools/read_xattrs.c
@@ -39,12 +39,12 @@
 #include <endian.h>
 #endif
 
+#include <stdlib.h>
+
 #include "squashfs_fs.h"
 #include "squashfs_swap.h"
 #include "xattr.h"
 #include "error.h"
-
-#include <stdlib.h>
 
 extern int read_fs_bytes(int, long long, int, void *);
 extern int read_block(int, long long, long long *, int, void *);

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -31,7 +31,12 @@
 #include "unsquashfs_info.h"
 #include "stdarg.h"
 
+#ifndef linux
+#include <sys/sysctl.h>
+#else
 #include <sys/sysinfo.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -2179,6 +2179,7 @@ void initialise_threads(int fragment_buffer_size, int data_buffer_size)
 	sigemptyset(&sigmask);
 	sigaddset(&sigmask, SIGQUIT);
 	sigaddset(&sigmask, SIGHUP);
+	sigaddset(&sigmask, SIGALRM);
 	if(pthread_sigmask(SIG_BLOCK, &sigmask, NULL) == -1)
 		EXIT_UNSQUASH("Failed to set signal mask in initialise_threads"
 			"\n");

--- a/squashfs-tools/unsquashfs.h
+++ b/squashfs-tools/unsquashfs.h
@@ -47,6 +47,10 @@
 #include <sys/ioctl.h>
 #include <sys/time.h>
 
+#ifndef FNM_EXTMATCH /* glibc extension */
+    #define FNM_EXTMATCH 0
+#endif
+
 #ifndef linux
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN

--- a/squashfs-tools/unsquashfs_info.c
+++ b/squashfs-tools/unsquashfs_info.c
@@ -97,31 +97,22 @@ void dump_state()
 void *info_thrd(void *arg)
 {
 	sigset_t sigmask;
-	struct timespec timespec = { .tv_sec = 1, .tv_nsec = 0 };
-	int sig, waiting = 0;
+	int sig, err, waiting = 0;
 
 	sigemptyset(&sigmask);
 	sigaddset(&sigmask, SIGQUIT);
 	sigaddset(&sigmask, SIGHUP);
+	sigaddset(&sigmask, SIGALRM);
 
 	while(1) {
-		if(waiting)
-			sig = sigtimedwait(&sigmask, NULL, &timespec);
-		else
-			sig = sigwaitinfo(&sigmask, NULL);
+		err = sigwait(&sigmask, &sig);
 
-		if(sig == -1) {
+		if(err == -1) {
 			switch(errno) {
-			case EAGAIN:
-				/* interval timed out */
-				waiting = 0;
-				/* FALLTHROUGH */
 			case EINTR:
-				/* if waiting, the wait will be longer, but
-				   that's OK */
 				continue;
 			default:
-				BAD_ERROR("sigtimedwait/sigwaitinfo failed "
+				BAD_ERROR("sigwait failed "
 					"because %s\n", strerror(errno));
 			}
 		}
@@ -133,8 +124,12 @@ void *info_thrd(void *arg)
 			/* set one second interval period, if ^\ received
 			   within then, dump queue and cache status */
 			waiting = 1;
-		} else
+			alarm(1);
+		} else if (sig == SIGQUIT) {
 			dump_state();
+		} else if (sig == SIGALRM) {
+			waiting = 0;
+		}
 	}
 }
 

--- a/squashfs-tools/unsquashfs_xattr.c
+++ b/squashfs-tools/unsquashfs_xattr.c
@@ -27,6 +27,11 @@
 
 #include <sys/xattr.h>
 
+#ifdef XATTR_NOFOLLOW /* Apple's xattrs */
+    #define lsetxattr(path_, name_, val_, sz_, flags_) \
+        setxattr(path_, name_, val_, sz_, 0, flags_ | XATTR_NOFOLLOW)
+#endif
+
 #define NOSPACE_MAX 10
 
 extern int root_process;

--- a/squashfs-tools/xattr.c
+++ b/squashfs-tools/xattr.c
@@ -36,6 +36,13 @@
 #include <stdlib.h>
 #include <sys/xattr.h>
 
+#ifdef XATTR_NOFOLLOW /* Apple's xattrs */
+    #define llistxattr(path_, buf_, sz_) \
+        listxattr(path_, buf_, sz_, XATTR_NOFOLLOW)
+    #define lgetxattr(path_, name_, val_, sz_) \
+        getxattr(path_, name_, val_, sz_, 0, XATTR_NOFOLLOW)
+#endif
+
 #include "squashfs_fs.h"
 #include "squashfs_swap.h"
 #include "mksquashfs.h"

--- a/squashfs-tools/xattr.c
+++ b/squashfs-tools/xattr.c
@@ -22,6 +22,14 @@
  * xattr.c
  */
 
+#ifndef linux
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#else
+#include <endian.h>
+#endif
+
 #define TRUE 1
 #define FALSE 0
 


### PR DESCRIPTION
Makes unsquashfs and mksquashfs compile and run on Mac OS X 10.7 and higher, as well as the most recent versions of FreeBSD, OpenBSD, NetBSD and DragonflyBSD. They continue to work on Linux as well, of course.
