### PR TITLE
unsquashfs: modify xattrs after other changes

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -821,8 +821,6 @@ int set_attributes(char *pathname, int mode, uid_t uid, gid_t guid, time_t time,
 {
 	struct utimbuf times = { time, time };
 
-	write_xattr(pathname, xattr);
-
 	if(utime(pathname, &times) == -1) {
 		ERROR("set_attributes: failed to set time on %s, because %s\n",
 			pathname, strerror(errno));
@@ -844,6 +842,8 @@ int set_attributes(char *pathname, int mode, uid_t uid, gid_t guid, time_t time,
 			pathname, strerror(errno));
 		return FALSE;
 	}
+
+	write_xattr(pathname, xattr);
 
 	return TRUE;
 }


### PR DESCRIPTION
Fixes a bug in which security capabilities were not properly set on
written files.  chown(2) resets all capabilities so it should be run
before setting xattrs instead of afterwards.
