### PR TITLE
Add -offset option to skip n bytes

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -98,6 +98,7 @@ int old_exclude = TRUE;
 int use_regex = FALSE;
 int nopad = FALSE;
 int exit_on_error = FALSE;
+static off_t squashfs_start_offset = 0;
 
 long long global_uid = -1, global_gid = -1;
 
@@ -516,9 +517,9 @@ int read_fs_bytes(int fd, long long byte, int bytes, void *buff)
 
 	pthread_cleanup_push((void *) pthread_mutex_unlock, &pos_mutex);
 	pthread_mutex_lock(&pos_mutex);
-	if(lseek(fd, off, SEEK_SET) == -1) {
+	if(lseek(fd, off+squashfs_start_offset, SEEK_SET) == -1) {
 		ERROR("read_fs_bytes: Lseek on destination failed because %s, "
-			"offset=0x%llx\n", strerror(errno), off);
+			"offset=0x%llx\n", strerror(errno), off+squashfs_start_offset);
 		res = 0;
 	} else if(read_bytes(fd, buff, bytes) < bytes) {
 		ERROR("Read on destination failed\n");
@@ -557,10 +558,10 @@ void write_destination(int fd, long long byte, int bytes, void *buff)
 	pthread_cleanup_push((void *) pthread_mutex_unlock, &pos_mutex);
 	pthread_mutex_lock(&pos_mutex);
 
-	if(lseek(fd, off, SEEK_SET) == -1) {
+	if(lseek(fd, off+squashfs_start_offset, SEEK_SET) == -1) {
 		ERROR("write_destination: Lseek on destination "
 			"failed because %s, offset=0x%llx\n", strerror(errno),
-			off);
+			off+squashfs_start_offset);
 		BAD_ERROR("Probably out of space on output %s\n",
 			block_device ? "block device" : "filesystem");
 	}
@@ -2315,9 +2316,9 @@ void *writer(void *arg)
 		pthread_cleanup_push((void *) pthread_mutex_unlock, &pos_mutex);
 		pthread_mutex_lock(&pos_mutex);
 
-		if(lseek(fd, off, SEEK_SET) == -1) {
+		if(lseek(fd, off+squashfs_start_offset, SEEK_SET) == -1) {
 			ERROR("writer: Lseek on destination failed because "
-				"%s, offset=0x%llx\n", strerror(errno), off);
+				"%s, offset=0x%llx\n", strerror(errno), off+squashfs_start_offset);
 			BAD_ERROR("Probably out of space on output "
 				"%s\n", block_device ? "block device" :
 				"filesystem");
@@ -5341,6 +5342,15 @@ print_compressor_options:
 			force_progress = TRUE;
 		else if(strcmp(argv[i], "-no-exports") == 0)
 			exportable = FALSE;
+        else if(strcmp(argv[i], "-offset") == 0 ||
+				strcmp(argv[i], "-o") ==0) {
+			if(++i == argc) {
+				ERROR("%s: %s offset missing argument\n", argv[0],
+							argv[i - 1]);
+				exit(1);
+			}
+			squashfs_start_offset = (off_t)atol(argv[i]);
+        }        
 		else if(strcmp(argv[i], "-processors") == 0) {
 			if((++i == argc) || !parse_num(argv[i], &processors)) {
 				ERROR("%s: -processors missing or invalid "
@@ -5641,6 +5651,9 @@ printOptions:
 			ERROR("\nMiscellaneous options:\n");
 			ERROR("-root-owned\t\talternative name for -all-root"
 				"\n");
+			ERROR("-o <offset>\t\tSkip <offset> bytes at the "
+				"beginning of the file.\n\t\t\t"
+				"Default 0 bytes\n");            
 			ERROR("-noInodeCompression\talternative name for -noI"
 				"\n");
 			ERROR("-noDataCompression\talternative name for -noD"

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -42,6 +42,7 @@ struct cache *fragment_cache, *data_cache;
 struct queue *to_reader, *to_inflate, *to_writer, *from_writer;
 pthread_t *thread, *inflator_thread;
 pthread_mutex_t	fragment_mutex;
+static off_t squashfs_start_offset = 0;
 
 /* user options that control parallelisation */
 int processors = -1;
@@ -631,7 +632,7 @@ int read_fs_bytes(int fd, long long byte, int bytes, void *buff)
 	TRACE("read_bytes: reading from position 0x%llx, bytes %d\n", byte,
 		bytes);
 
-	if(lseek(fd, off, SEEK_SET) == -1) {
+	if(lseek(fd, off + squashfs_start_offset, SEEK_SET) == -1) {
 		ERROR("Lseek failed because %s\n", strerror(errno));
 		return FALSE;
 	}
@@ -2544,6 +2545,14 @@ int main(int argc, char *argv[])
 				exit(1);
 			}
 			dest = argv[i];
+        		} else if (strcmp(argv[i], "-offset") == 0 ||
+				strcmp(argv[i], "-o") == 0) {
+			if(++i == argc) {
+				fprintf(stderr, "%s: -offset missing argument\n",
+					argv[0]);
+				exit(1);
+			}
+			squashfs_start_offset = (off_t)atol(argv[i]);
 		} else if(strcmp(argv[i], "-processors") == 0 ||
 				strcmp(argv[i], "-p") == 0) {
 			if((++i == argc) || 
@@ -2636,6 +2645,8 @@ options:
 				"copyright information\n");
 			ERROR("\t-d[est] <pathname>\tunsquash to <pathname>, "
 				"default \"squashfs-root\"\n");
+			ERROR("\t-o[ffset] <bytes>\tskip <bytes> at start of input file, "
+				"default \"0\"\n");
 			ERROR("\t-n[o-progress]\t\tdon't display the progress "
 				"bar\n");
 			ERROR("\t-no[-xattrs]\t\tdon't extract xattrs in file system"


### PR DESCRIPTION
This patch, when merged, adds an -offset option to skip n bytes which is very useful in situations where the squashfs image doesn't start at byte 0 of the file. This is quite common in the embedded space.

Patch for unsquashfs originally created by Yura Siamashka.
Patch for mksquashfs created by myself.
