### PR TITLE
build: address a few issues for building squashfs-tools on OS X

### DIFF
--- a/squashfs-tools/action.c
+++ b/squashfs-tools/action.c
@@ -2284,9 +2284,12 @@ static char *get_start(char *s, int n)
 
 static int subpathname_fn(struct atom *atom, struct action_data *action_data)
 {
-	return fnmatch(atom->argv[0], get_start(strdupa(action_data->subpath),
+	char *subpath_copy = strdup(action_data->subpath);
+	int ret = fnmatch(atom->argv[0], get_start(subpath_copy,
 		count_components(atom->argv[0])),
-		FNM_PATHNAME|FNM_PERIOD|FNM_EXTMATCH) == 0;
+		FNM_PATHNAME|FNM_PERIOD|FNM_EXTMATCH);
+	free(subpath_copy);
+	return ret == 0;
 }
 
 /*

--- a/squashfs-tools/xattr.h
+++ b/squashfs-tools/xattr.h
@@ -76,6 +76,12 @@ extern void write_xattr(char *, unsigned int);
 extern int read_xattrs_from_disk(int, struct squashfs_super_block *);
 extern struct xattr_list *get_xattr(int, unsigned int *, int);
 extern void free_xattr(struct xattr_list *, int);
+
+#ifdef __APPLE__
+#define llistxattr(f, buf, len) (listxattr(f, buf, len, XATTR_NOFOLLOW))
+#define lgetxattr(f, nam, buf, len) (getxattr(f, nam, buf, len, 0, XATTR_NOFOLLOW))
+#endif
+
 #else
 static inline int get_xattrs(int fd, struct squashfs_super_block *sBlk)
 {


### PR DESCRIPTION
The xattr stuff was easy to fix with findings from the web.
One place is this:
https://github.com/pieceofsummer/squashfs-tools/blob/master/squashfs-tools/macosx.h

The `strdupa()` was replaced with `strdup()`.

And the `sigtimedwait()` and `sigwaitinfo()` will need a bit more work than I have time atm :)
I may come back later.

After that, `osx` can be added to after this line: https://github.com/plougher/squashfs-tools/pull/29/commits/1c3d2e8e5d71ebe9391219f6576f3165aed345a2#diff-354f30a63fb0907d4ad57269548329e3R13

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>