### PR TITLE
Add -pseudo-override flag to override -all-root and -force-uid/gid permissions on -p or -pf pseudo defintions

### DIFF
--- a/squashfs-tools/mksquashfs.h
+++ b/squashfs-tools/mksquashfs.h
@@ -59,6 +59,7 @@ struct inode_info {
 	char			read;
 	char			root_entry;
 	char			pseudo_file;
+	char			pseudo_file_m;
 	char			no_fragments;
 	char			always_use_fragments;
 	char			noD;
@@ -110,6 +111,7 @@ struct append_file {
 #define PSEUDO_FILE_PROCESS	2
 
 #define IS_PSEUDO(a)		((a)->pseudo_file)
+#define IS_PSEUDO_M(a)		((a)->pseudo_file_m)
 #define IS_PSEUDO_PROCESS(a)	((a)->pseudo_file & PSEUDO_FILE_PROCESS)
 #define IS_PSEUDO_OTHER(a)	((a)->pseudo_file & PSEUDO_FILE_OTHER)
 


### PR DESCRIPTION
This is useful when you want to use pseudo definitions when you are not building the file system as root.

For example:
`mksquashfs rootfs root.bin -all-root -pseudo-override -pf pseudo_file`
This will override the default -all-root behavior only on definitions in pseudo_file.

I think this new option is the answer to this question on the mailing list:

>[Squashfs-devel] Setting file capabilities in a squashfs file system
>From: Henrik Grindal Bakken <hgb@if...> - 2017-08-21 10:53:18
>  --
> Hi.  I have a situation where I want to have file capabilities set on
> files in a squashfs, but I am not root when creating the file system.
> 
> Since I'm not root, I cannot add file caps in the file system I am
> creating the squashfs from, and I haven't found a way of adding them to
> the squashfs later.
> 
> Is this possible?
> 
> -- 
> Henrik Grindal Bakken <hgb@...>
> PGP ID: 8D436E52
> Fingerprint: 131D 9590 F0CF 47EF 7963  02AF 9236 D25A 8D43 6E52

