### PR TITLE
mkquashfs: Add `-noId` option to leave the uid/gid table uncompressed

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -91,6 +91,7 @@ int noF = FALSE;
 int no_fragments = FALSE;
 int always_use_fragments = FALSE;
 int noI = FALSE;
+int noId = FALSE;
 int noD = FALSE;
 int silent = TRUE;
 int exportable = TRUE;
@@ -663,7 +664,7 @@ long long write_id_table()
 		SQUASHFS_SWAP_INTS(&id_table[i]->id, p + i, 1);
 	}
 
-	return generic_write_table(id_bytes, p, 0, NULL, noI);
+	return generic_write_table(id_bytes, p, 0, NULL, noI || noId);
 }
 
 
@@ -5524,6 +5525,10 @@ print_compressor_options:
 				strcmp(argv[i], "-noInodeCompression") == 0)
 			noI = TRUE;
 
+		else if(strcmp(argv[i], "-noId") == 0 ||
+				strcmp(argv[i], "-noIdTableCompression") == 0)
+			noId = TRUE;
+
 		else if(strcmp(argv[i], "-noD") == 0 ||
 				strcmp(argv[i], "-noDataCompression") == 0)
 			noD = TRUE;
@@ -5594,6 +5599,8 @@ printOptions:
 			ERROR("-xattrs\t\t\tstore extended attributes" XOPT_STR
 				"\n");
 			ERROR("-noI\t\t\tdo not compress inode table\n");
+			ERROR("-noId\t\t\tdo not compress the uid/gid table"
+				" (implied by -noI)\n");
 			ERROR("-noD\t\t\tdo not compress data blocks\n");
 			ERROR("-noF\t\t\tdo not compress fragment blocks\n");
 			ERROR("-noX\t\t\tdo not compress extended "
@@ -5678,6 +5685,8 @@ printOptions:
 				"beginning of the file.\n\t\t\t"
 				"Default 0 bytes\n");            
 			ERROR("-noInodeCompression\talternative name for -noI"
+				"\n");
+			ERROR("-noIdTableCompression\talternative name for -noId"
 				"\n");
 			ERROR("-noDataCompression\talternative name for -noD"
 				"\n");


### PR DESCRIPTION
## Motivation
For one of our projects ([1]), we need to distribute a rather large
rootfs containing cross-compile toolchains for every platform we
support. In general, we distribute this rootfs as a .tar.gz and
user usernamespaces on a user's machine to allow an unpriviledged
user to make use of this rootfs. We want to make use of the same
image on CI systems, however, the large uncompressed size of the
rootfs makes this impractical due to CI system disk space limitations
(on the other hand, we do tend to have sudo access on these systems,
since their abstrcation expose VMs with root access).
To work around this, we also distribute the rootfs as squashfs
image, thus alleviating the need to uncompress in image and allowing
the system to work in limited disk space sitatuions. This presents
another problem however: The system assumes that the uids/gids
will be those of the current, unpriviledged user (since that's what
happens in the .tar.gz case). However, since the uids/gids inside
the image do not necessarily match that of the CI system user,
the system gets confused. Luckily, since squashfs is storing
these ids separately, it is very easy to adjust the image without
uncompressing/re-compressing. This works very well as long as
the uid table is itself uncompressed. This happens to be always
true for our current image (likely because we're only using one id,
so compression will have a hard time compressing that), but we'd
be more comfortable if this was guaranteed by `mksquashfs`. Currently
the `-noI` option does also control the id table compression. However,
we would prefer not to give up the space savings from general metadata
compression just to leave the id table uncompressed. This patch
thus introduces a new `-noId` command line option to leave the id table
uncompressed.

[1] https://github.com/JuliaPackaging/BinaryBuilder.jl

## Implementation
The implementation is very simple, since the feature is already activated
by the noI switch (in conjunction with it's other effects). I followed
the implementation of `-noI` for argument processing. With this patch
`-noI` still implies no id table compression (or said another way implies
`-noId`) to avoid changing behavior for those using `-noId`.