### PR TITLE
mksquashfs/unsquashfs: use sys/sysmacros.h for makedev()

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stddef.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -33,6 +33,7 @@
 #include "fnmatch_compat.h"
 
 #include <sys/sysinfo.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>


### PR DESCRIPTION
Newer versions of libc6 warn about the use of makedev() when it
is not included via <sys/sysmacros.h>. The full warning is:

```
warning: In the GNU C Library, "makedev" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "makedev", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "makedev", you should undefine it after including <sys/types.h>.
```

This patch adds this include. I checked and sysmacros.h is available
at least until libc6 from 2012 (the oldest I had available) so the
risk of breaking builds is small.