### PR TITLE
mksquashfs: Add uid/gid mapping flags

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -5687,7 +5687,7 @@ print_compressor_options:
 				exit(1);
 			}
 			if (parse_ugid_map(argv[i], gid_mapping,
-					   &uid_map_count) != 0) {
+					   &gid_map_count) != 0) {
 				ERROR("%s: -gid-map: invalid mapping\n",
 				      argv[0]);
 				exit(1);

--- a/squashfs-tools/mksquashfs.h
+++ b/squashfs-tools/mksquashfs.h
@@ -147,8 +147,8 @@ extern int read_fs_bytes(int, long long, int, void *);
 extern void add_file(long long, long long, long long, unsigned int *, int,
 	unsigned int, int, int);
 extern struct id *create_id(unsigned int);
-extern unsigned int get_uid(unsigned int);
-extern unsigned int get_guid(unsigned int);
+extern unsigned int get_uid(unsigned int, int);
+extern unsigned int get_guid(unsigned int, int);
 extern int read_bytes(int, void *, int);
 extern unsigned short get_checksum_mem(char *, int);
 #endif

--- a/squashfs-tools/read_fs.c
+++ b/squashfs-tools/read_fs.c
@@ -214,8 +214,8 @@ int scan_inode_table(int fd, long long start, long long end,
 		/* bad type, corrupted filesystem */
 		goto corrupted;
 
-	get_uid(id_table[dir_inode->base.uid]);
-	get_guid(id_table[dir_inode->base.guid]);
+	get_uid(id_table[dir_inode->base.uid], 0);
+	get_guid(id_table[dir_inode->base.guid], 0);
 
 	/* allocate fragment to file mapping table */
 	file_mapping = calloc(sBlk->fragments, sizeof(struct append_file *));
@@ -234,8 +234,8 @@ int scan_inode_table(int fd, long long start, long long end,
 			(unsigned int) (cur_ptr - *inode_table),
 			base.inode_type);
 
-		get_uid(id_table[base.uid]);
-		get_guid(id_table[base.guid]);
+		get_uid(id_table[base.uid], 0);
+		get_guid(id_table[base.guid], 0);
 
 		switch(base.inode_type) {
 		case SQUASHFS_FILE_TYPE: {


### PR DESCRIPTION
Add flags that allow the user to choose uid/gid mappings before writing
the inodes. This is helpful to create container images that need
uids/gids to be shifted.

Signed-off-by: Luis Héctor Chávez <lhchavez@google.com>