### PR TITLE
mksquashfs: Allow setting selinux xattrs through file_context

### DIFF
--- a/squashfs-tools/Makefile
+++ b/squashfs-tools/Makefile
@@ -114,6 +114,22 @@ XATTR_SUPPORT = 1
 # default.  Users can enable xattrs by using the -xattrs option.
 XATTR_DEFAULT = 1
 
+###############################################
+#  SELinux labelling support build options    #
+###############################################
+#
+# Building SELinux labelling support for Mksquashfs. This provides an
+# alternative to reading SELinux labels from the filesystem with XATTR
+# support. It is possible to label the files in the Squashfs filesystem
+# differently than the source filesystem with this option.
+#
+# Note that SELinux labelling support requries that XATTR is also
+# supported.
+#
+# If your build/target environment does not have support for SELinux then
+# comment out the next line to build Mksquashfs without SELinux labelling
+# support.
+SELINUX_SUPPORT = 1
 
 ###############################################
 #        End of BUILD options section         #
@@ -205,6 +221,14 @@ CFLAGS += -DXATTR_SUPPORT
 endif
 MKSQUASHFS_OBJS += xattr.o read_xattrs.o
 UNSQUASHFS_OBJS += read_xattrs.o unsquashfs_xattr.o
+
+# SELinux support is only available if XATTR support is available
+ifeq ($(SELINUX_SUPPORT),1)
+CFLAGS += -DSELINUX_SUPPORT
+MKSQUASHFS_OBJS += selinux.o
+LIBS += -lselinux
+endif
+
 endif
 
 #

--- a/squashfs-tools/selinux.c
+++ b/squashfs-tools/selinux.c
@@ -1,0 +1,61 @@
+/* Copyright 2015 The Android Open Source Project */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <selinux/label.h>
+
+#include "error.h"
+#include "selinux.h"
+#include "xattr.h"
+
+
+#define ARRAY_SIZE(a)	(sizeof(a) / sizeof((a)[0]))
+
+
+squashfs_selinux_handle *get_sehnd(const char *context_file) {
+	struct selinux_opt seopts[] = {
+		{
+			.type = SELABEL_OPT_PATH,
+			.value = context_file
+		}
+	};
+	struct selabel_handle *sehnd =
+		selabel_open(SELABEL_CTX_FILE, seopts, ARRAY_SIZE(seopts));
+
+	if(sehnd == NULL)
+		BAD_ERROR("Failure calling selabel_open: %s\n", strerror(errno));
+
+	return sehnd;
+}
+
+static char *set_selabel(const char *path, unsigned int mode, struct selabel_handle *sehnd) {
+	char *secontext;
+	if(sehnd == NULL)
+		BAD_ERROR("selabel handle is NULL\n");
+
+	int full_name_size = strlen(path) + 2;
+	char* full_name = (char*) malloc(full_name_size);
+	if(full_name == NULL)
+		MEM_ERROR();
+
+	full_name[0] = '/';
+	strncpy(full_name + 1, path, full_name_size - 1);
+
+	if(selabel_lookup(sehnd, &secontext, full_name, mode))
+		secontext = strdup("u:object_r:unlabeled:s0");
+
+	free(full_name);
+	return secontext;
+}
+
+void read_selinux_xattr_from_context_file(char *filename, int mode,
+	squashfs_selinux_handle *sehnd, struct xattr_list *xattrs) {
+	char *attr_val;
+
+	xattrs->type = get_prefix(xattrs, "security.selinux");
+	attr_val = set_selabel(filename, mode, sehnd);
+	xattrs->value = (void *)attr_val;
+	xattrs->vsize = strlen(attr_val);
+}
+

--- a/squashfs-tools/selinux.h
+++ b/squashfs-tools/selinux.h
@@ -1,0 +1,27 @@
+/* Copyright 2015 The Android Open Source Project */
+
+#ifndef SELINUX_H
+#define SELINUX_H
+
+#include "xattr.h"
+
+#ifdef SELINUX_SUPPORT
+typedef struct selabel_handle squashfs_selinux_handle;
+extern squashfs_selinux_handle *get_sehnd(const char *context_file);
+extern void read_selinux_xattr_from_context_file(char *filename, int mode,
+	struct selabel_handle *sehnd, struct xattr_list *xattrs);
+#else
+typedef void squashfs_selinux_handle;
+
+
+static squashfs_selinux_handle *get_sehnd(const char *context_file) {
+	return NULL;
+}
+
+
+static void read_selinux_xattr_from_context_file(char *filename, int mode,
+	squashfs_selinux_handle *sehnd, struct xattr_list *xattrs) {
+}
+#endif
+
+#endif

--- a/squashfs-tools/xattr.h
+++ b/squashfs-tools/xattr.h
@@ -24,6 +24,8 @@
  * xattr.h
  */
 
+#include "squashfs_fs.h"
+
 #define XATTR_VALUE_OOL		SQUASHFS_XATTR_VALUE_OOL
 #define XATTR_PREFIX_MASK	SQUASHFS_XATTR_PREFIX_MASK
 
@@ -66,6 +68,7 @@ struct prefix {
 extern int generate_xattrs(int, struct xattr_list *);
 
 #ifdef XATTR_SUPPORT
+extern int get_prefix(struct xattr_list *xattr, char *name);
 extern int get_xattrs(int, struct squashfs_super_block *);
 extern int read_xattrs(void *);
 extern long long write_xattrs();
@@ -77,6 +80,12 @@ extern int read_xattrs_from_disk(int, struct squashfs_super_block *);
 extern struct xattr_list *get_xattr(int, unsigned int *, int);
 extern void free_xattr(struct xattr_list *, int);
 #else
+static inline int get_prefix(struct xattr_list *xattr, char *name)
+{
+	return -1;
+}
+
+
 static inline int get_xattrs(int fd, struct squashfs_super_block *sBlk)
 {
 	if(sBlk->xattr_id_table_start != SQUASHFS_INVALID_BLK) {


### PR DESCRIPTION
Add a context-file flag that allows passing an selinux security context
file to set security.selinux xattrs rather than reading xattrs from
filesystem's source directory. This allows squashfs filesystems with
SELinux attributes to be made even when the building host kernel does
not have SELinux enabled.

Based on the original change to allow the use of SELinux file_contexts
directly from the source file which was committed to Android's copy
of squashfs-tools and written by Mohamad Ayyash <mkayyash@google.com>