### PR TITLE
mksquashfs/unsquashfs: fix compilation with glibc 2.25+

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -35,6 +35,7 @@
 #include <stddef.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <dirent.h>

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -33,6 +33,7 @@
 #include "fnmatch_compat.h"
 
 #include <sys/sysinfo.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>


### PR DESCRIPTION
From glibc 2.25 release notes:
https://sourceware.org/ml/libc-alpha/2017-02/msg00079.html
"* The inclusion of <sys/sysmacros.h> by <sys/types.h> is deprecated.
  This means that in a future release, the macros “major”, “minor”, and
  “makedev” will only be available from <sys/sysmacros.h>."

See glibc bug https://sourceware.org/bugzilla/show_bug.cgi?id=19239 .