### PR TITLE
Debian patches

### DIFF
--- a/squashfs-tools/gzip_wrapper.h
+++ b/squashfs-tools/gzip_wrapper.h
@@ -24,7 +24,7 @@
  *
  */
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN

--- a/squashfs-tools/lz4_wrapper.h
+++ b/squashfs-tools/lz4_wrapper.h
@@ -24,7 +24,7 @@
  *
  */
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN

--- a/squashfs-tools/lzo_wrapper.h
+++ b/squashfs-tools/lzo_wrapper.h
@@ -24,7 +24,7 @@
  *
  */
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -52,7 +52,7 @@
 #include <ctype.h>
 #include <sys/sysinfo.h>
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
@@ -4343,7 +4343,7 @@ void initialise_threads(int readq, int fragq, int bwriteq, int fwriteq,
 		BAD_ERROR("Failed to set signal mask in intialise_threads\n");
 
 	if(processors == -1) {
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 		int mib[2];
 		size_t len = sizeof(processors);
 

--- a/squashfs-tools/read_fs.c
+++ b/squashfs-tools/read_fs.c
@@ -35,7 +35,7 @@
 #include <limits.h>
 #include <dirent.h>
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN

--- a/squashfs-tools/read_xattrs.c
+++ b/squashfs-tools/read_xattrs.c
@@ -31,7 +31,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN

--- a/squashfs-tools/squashfs_fs.h
+++ b/squashfs-tools/squashfs_fs.h
@@ -31,6 +31,12 @@
 #define SQUASHFS_MAGIC_SWAP		0x68737173
 #define SQUASHFS_START			0
 
+/*
+ * Squashfs + LZMA
+ */
+#define SQUASHFS_MAGIC_LZMA		0x71736873
+#define SQUASHFS_MAGIC_LZMA_SWAP	0x73687371
+
 /* size of metadata (inode and directory) blocks */
 #define SQUASHFS_METADATA_SIZE		8192
 #define SQUASHFS_METADATA_LOG		13

--- a/squashfs-tools/swap.c
+++ b/squashfs-tools/swap.c
@@ -19,7 +19,7 @@
  * swap.c
  */
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -799,6 +799,8 @@ int set_attributes(char *pathname, int mode, uid_t uid, gid_t guid, time_t time,
 	unsigned int xattr, unsigned int set_mode)
 {
 	struct utimbuf times = { time, time };
+	/* Mode bits that are only useful with root privileges */
+	mode_t root_mask = S_ISUID | S_ISGID | S_ISVTX;
 
 	if(utime(pathname, &times) == -1) {
 		ERROR("set_attributes: failed to set time on %s, because %s\n",
@@ -814,9 +816,9 @@ int set_attributes(char *pathname, int mode, uid_t uid, gid_t guid, time_t time,
 			return FALSE;
 		}
 	} else
-		mode &= ~07000;
+		mode &= ~(root_mask);
 
-	if((set_mode || (mode & 07000)) && chmod(pathname, (mode_t) mode) == -1) {
+	if((set_mode || (mode & root_mask)) && chmod(pathname, (mode_t) mode) == -1) {
 		ERROR("set_attributes: failed to change mode %s, because %s\n",
 			pathname, strerror(errno));
 		return FALSE;

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -1069,7 +1069,12 @@ int create_inode(char *pathname, struct inode *i)
 				FAILED = TRUE;
 			break;
 		case SQUASHFS_SYMLINK_TYPE:
-		case SQUASHFS_LSYMLINK_TYPE:
+		case SQUASHFS_LSYMLINK_TYPE: {
+			struct timespec times[2] = {
+				{ i->time, 0 },
+				{ i->time, 0 }
+			};
+
 			TRACE("create_inode: symlink, symlink_size %lld\n",
 				i->data);
 
@@ -1084,6 +1089,13 @@ int create_inode(char *pathname, struct inode *i)
 				break;
 			}
 
+			if (utimensat(AT_FDCWD, pathname, times,
+					AT_SYMLINK_NOFOLLOW) == -1) {
+				ERROR("create_inode: failed to set time on "
+					"%s, because %s\n", pathname,
+					strerror(errno));
+			}
+
 			write_xattr(pathname, i->xattr);
 	
 			if(root_process) {
@@ -1096,6 +1108,7 @@ int create_inode(char *pathname, struct inode *i)
 
 			sym_count ++;
 			break;
+		}
  		case SQUASHFS_BLKDEV_TYPE:
 	 	case SQUASHFS_CHRDEV_TYPE:
  		case SQUASHFS_LBLKDEV_TYPE:

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -2178,7 +2178,7 @@ void initialise_threads(int fragment_buffer_size, int data_buffer_size)
 			"\n");
 
 	if(processors == -1) {
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 		int mib[2];
 		size_t len = sizeof(processors);
 

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -1787,10 +1787,12 @@ int read_super(char *source)
 	 */
 	read_fs_bytes(fd, SQUASHFS_START, sizeof(struct squashfs_super_block),
 		&sBlk_4);
-	swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
+	swap = (sBlk_4.s_magic != SQUASHFS_MAGIC &&
+		sBlk_4.s_magic != SQUASHFS_MAGIC_LZMA);
 	SQUASHFS_INSWAP_SUPER_BLOCK(&sBlk_4);
 
-	if(sBlk_4.s_magic == SQUASHFS_MAGIC && sBlk_4.s_major == 4 &&
+	if((sBlk_4.s_magic == SQUASHFS_MAGIC ||
+			sBlk_4.s_magic == SQUASHFS_MAGIC_LZMA) && sBlk_4.s_major == 4 &&
 			sBlk_4.s_minor == 0) {
 		read_filesystem_tables = read_filesystem_tables_4;
 		memcpy(&sBlk, &sBlk_4, sizeof(sBlk_4));
@@ -1798,7 +1800,11 @@ int read_super(char *source)
 		/*
 		 * Check the compression type
 		 */
-		comp = lookup_compressor_id(sBlk.s.compression);
+		if (sBlk_4.s_magic == SQUASHFS_MAGIC_LZMA)
+			comp = lookup_compressor("lzma");
+		else
+			comp = lookup_compressor_id(sBlk.s.compression);
+
 		return TRUE;
 	}
 
@@ -1813,8 +1819,10 @@ int read_super(char *source)
 	 * Check it is a SQUASHFS superblock
 	 */
 	swap = 0;
-	if(sBlk_3.s_magic != SQUASHFS_MAGIC) {
-		if(sBlk_3.s_magic == SQUASHFS_MAGIC_SWAP) {
+	if(sBlk_3.s_magic != SQUASHFS_MAGIC &&
+			sBlk_3.s_magic != SQUASHFS_MAGIC_LZMA) {
+		if(sBlk_3.s_magic == SQUASHFS_MAGIC_SWAP ||
+				sBlk_3.s_magic == SQUASHFS_MAGIC_LZMA_SWAP) {
 			squashfs_super_block_3 sblk;
 			ERROR("Reading a different endian SQUASHFS filesystem "
 				"on %s\n", source);
@@ -1878,7 +1886,11 @@ int read_super(char *source)
 	/*
 	 * 1.x, 2.x and 3.x filesystems use gzip compression.
 	 */
-	comp = lookup_compressor("gzip");
+	if (sBlk.s.s_magic == SQUASHFS_MAGIC_LZMA)
+		comp = lookup_compressor("lzma");
+	else
+		comp = lookup_compressor("gzip");
+
 	return TRUE;
 
 failed_mount:

--- a/squashfs-tools/unsquashfs.h
+++ b/squashfs-tools/unsquashfs.h
@@ -46,7 +46,7 @@
 #include <sys/ioctl.h>
 #include <sys/time.h>
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN

--- a/squashfs-tools/xz_wrapper.h
+++ b/squashfs-tools/xz_wrapper.h
@@ -24,7 +24,7 @@
  *
  */
 
-#ifndef linux
+#if !defined(linux) && !defined(__GLIBC__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN


### PR DESCRIPTION
I realized that most of the patches we carry in Gentoo are just copied from Debian. Many have already been sent upstream to the SF.net mailing list, and many (all?) are part of the [squashfskit](https://github.com/squashfskit/squashfskit) fork.