### PR TITLE
Fix return type of write_xattr

### DIFF
--- a/squashfs-tools/xattr.h
+++ b/squashfs-tools/xattr.h
@@ -110,8 +110,9 @@ static inline void restore_xattrs()
 }
 
 
-static inline void write_xattr(char *pathname, unsigned int xattr)
+static inline int write_xattr(char *pathname, unsigned int xattr)
 {
+	return 0;
 }
 
 


### PR DESCRIPTION
In the non-XATTR_SUPPORT part the return type of write_xattr() does not match XATTR_SUPPORT, preventing compilation.