### PR TITLE
Improve unsquashfs handling of special files

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -55,7 +55,7 @@ squashfs_operations *(*read_filesystem_tables)();
 struct compressor *comp;
 
 int bytes = 0, swap, file_count = 0, dir_count = 0, sym_count = 0,
-	dev_count = 0, fifo_count = 0;
+	dev_count = 0, fifo_count = 0, socket_count = 0;
 struct hash_table_entry *inode_table_hash[65536], *directory_table_hash[65536];
 int fd;
 unsigned int cached_frag = SQUASHFS_INVALID_FRAG;
@@ -1192,7 +1192,14 @@ int create_inode(char *pathname, struct inode *i)
 		case SQUASHFS_SOCKET_TYPE:
 		case SQUASHFS_LSOCKET_TYPE:
 			TRACE("create_inode: socket\n");
-			ERROR("create_inode: socket %s ignored\n", pathname);
+
+			if (mknod(pathname, S_IFSOCK | i->mode, 0) == -1) {
+				ERROR("create_inode: failed to create socket %s, "
+					"because %s\n",
+					pathname, strerror(errno));
+				goto failed;
+			}
+			socket_count++;
 			break;
 		default:
 			EXIT_UNSQUASH_STRICT("Unknown inode type %d in create_inode_table!\n",
@@ -2217,7 +2224,7 @@ void *progress_thread(void *arg)
 		if(progress_enabled) {
 			pthread_mutex_lock(&screen_mutex);
 			progress_bar(sym_count + dev_count +
-				fifo_count + cur_blocks, total_inodes -
+				fifo_count + socket_count + cur_blocks, total_inodes -
 				total_files + total_blocks, columns);
 			pthread_mutex_unlock(&screen_mutex);
 		}
@@ -2410,7 +2417,7 @@ void disable_progress_bar()
 {
 	pthread_mutex_lock(&screen_mutex);
 	if(progress_enabled) {
-		progress_bar(sym_count + dev_count + fifo_count + cur_blocks,
+		progress_bar(sym_count + dev_count + fifo_count + socket_count + cur_blocks,
 			total_inodes - total_files + total_blocks, columns);
 		printf("\n");
 	}
@@ -2983,6 +2990,7 @@ options:
 		printf("created %d symlinks\n", sym_count);
 		printf("created %d devices\n", dev_count);
 		printf("created %d fifos\n", fifo_count);
+		printf("created %d sockets\n", socket_count);
 	}
 
 	return exit_code;

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -1133,19 +1133,22 @@ int create_inode(char *pathname, struct inode *i)
  		case SQUASHFS_LBLKDEV_TYPE:
 	 	case SQUASHFS_LCHRDEV_TYPE: {
 			int chrdev = 0;
+			unsigned major, minor;
 			if ( i->type == SQUASHFS_CHRDEV_TYPE ||
 					i->type == SQUASHFS_LCHRDEV_TYPE)
 				chrdev = 1;
 
 			TRACE("create_inode: dev, rdev 0x%llx\n", i->data);
-
 			if(root_process) {
 				if(force)
 					unlink(pathname);
 
+				/* Ripped from new_decode_dev() in kernel sources. */
+				major = (i->data & 0xfff00) >> 8;
+				minor = (i->data & 0xff) | ((i->data >> 12) & 0xfff00);
+
 				res = mknod(pathname, chrdev ? S_IFCHR : S_IFBLK,
-						makedev((i->data >> 8) & 0xff,
-						i->data & 0xff));
+						makedev(major, minor));
 				if(res == -1) {
 					EXIT_UNSQUASH_STRICT("create_inode: failed to create "
 						"%s device %s, because %s\n",


### PR DESCRIPTION
Fix two deficiencies in unsquashfs: unix domain sockets were not created; and devnode major/minor numbers in the range 256-4095 were truncated to 8 bits.

Trivial test shell scripts attached (as .txt, because github).

I do not know best practices for portability in this repo; this code could certainly be wrapped in #ifdef linux is that is desirable.

[test-devnodes.sh.txt](https://github.com/plougher/squashfs-tools/files/3591619/test-devnodes.sh.txt)
[test-sockets.sh.txt](https://github.com/plougher/squashfs-tools/files/3591620/test-sockets.sh.txt)
