### PR TITLE
Fix error when appending to existing filesystem.

### DIFF
--- a/squashfs-tools/xattr.c
+++ b/squashfs-tools/xattr.c
@@ -651,8 +651,9 @@ int get_xattrs(int fd, struct squashfs_super_block *sBlk)
 	 * name:value pairs, and add them to the in-memory xattr cache
 	 */
 	for(i = 0; i < ids; i++) {
-		struct xattr_list *xattr_list = get_xattr(i, &count, &res);
-		if(res) {
+	    	int failed;
+		struct xattr_list *xattr_list = get_xattr(i, &count, &failed);
+		if(failed) {
 			free_xattr(xattr_list, count);
 			return FALSE;
 		}


### PR DESCRIPTION
In get_xattrs(), the 'res' variable was passed to get_xattr() for use as a failure flag. On success, 'res' is then set to zero and ends up being the return value from get_xattrs(). A zero return from get_xattrs() is interpreted as failure in read_filesystem(), which prevents appending from working. This is a regression since 4.3 release.

Fix by using a new variable for failure indication instead of inappropriately reusing 'res'.

Test case (fails without patch, succeeds with):

rm -f /tmp/test.sqfs && touch /tmp/1 && touch /tmp/2 && ./mksquashfs /tmp/1 /tmp/test.sqfs && ./mksquashfs /tmp/2 /tmp/test.sqfs