### PR TITLE
mksquashfs: pad with 0xff to accommodate FLASH

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -4949,7 +4949,9 @@ void write_filesystem_tables(struct squashfs_super_block *sBlk, int nopad)
 	write_destination(fd, SQUASHFS_START, sizeof(*sBlk), sBlk);
 
 	if(!nopad && (i = bytes & (4096 - 1))) {
-		char temp[4096] = {0};
+		char temp[4096];
+
+		memset(temp, 0xff, sizeof(temp));
 		write_destination(fd, bytes, 4096 - i, temp);
 	}
 


### PR DESCRIPTION
From the Commit message of the attached patch:

This patch changes mksquashfs to pad generated images with
a 0xff pattern rather than 0x00. The reason being that when
a image is written to SLC NOR/NAND flash, the individual cell
that will hold the padding needs to be "programmed" to produce
the "0" when read. This will reduce a tiny bit of wear and
tear in this situations and should be harmless to all other
contexts in which squashfs is in use.

I think this must have come up in the discussion before and I was looking around for older patches like this, but didn't see one. Of course, this patch is reduced to just fit SLC NOR flashes needs. If there's more than meets the eye, please let me know! 