### PR TITLE
Make strict-errors stricter in unsquashfs; add -one-file-system option to mksquashfs

### DIFF
--- a/squashfs-tools/mksquashfs.h
+++ b/squashfs-tools/mksquashfs.h
@@ -36,6 +36,7 @@ struct dir_info {
 	struct dir_ent		*dir_ent;
 	struct dir_ent		*list;
 	DIR			*linuxdir;
+	dev_t			devnum;
 };
 
 struct dir_ent {

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -2102,15 +2102,14 @@ void *writer(void *arg)
 				failed = TRUE;
 			}
 
-			if(failed)
-				continue;
+			if(!failed) {
+				res = write_block(file_fd, block->buffer->data +
+					block->offset, block->size, hole, file->sparse);
 
-			res = write_block(file_fd, block->buffer->data +
-				block->offset, block->size, hole, file->sparse);
-
-			if(res == FALSE) {
-				EXIT_UNSQUASH_IGNORE("writer: failed to write file %s\n", file->pathname);
-				failed = TRUE;
+				if(res == FALSE) {
+					EXIT_UNSQUASH_IGNORE("writer: failed to write file %s\n", file->pathname);
+					failed = TRUE;
+				}
 			}
 
 			hole = 0;

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -806,7 +806,7 @@ int set_attributes(char *pathname, int mode, uid_t uid, gid_t guid, time_t time,
 		return FALSE;
 	}
 
-	if(root_process) {
+	if(root_process || strict_errors) {
 		if(chown(pathname, uid, guid) == -1) {
 			EXIT_UNSQUASH_STRICT("set_attributes: failed to change uid and gids "
 				"on %s, because %s\n", pathname,
@@ -823,7 +823,7 @@ int set_attributes(char *pathname, int mode, uid_t uid, gid_t guid, time_t time,
 		 * sticky bit was included in the mode, try again without the
 		 * sticky bit. Otherwise, fail with an error message.
 		 */
-		if (root_process || errno != EPERM || !(mode & 01000) ||
+		if (root_process || strict_errors || errno != EPERM || !(mode & 01000) ||
 				chmod(pathname, (mode_t) (mode & ~01000)) == -1) {
 			EXIT_UNSQUASH_STRICT("set_attributes: failed to change mode %s, because %s\n",
 				pathname, strerror(errno));
@@ -1111,7 +1111,7 @@ int create_inode(char *pathname, struct inode *i)
 			if(res == FALSE)
 				failed = TRUE;
 	
-			if(root_process) {
+			if(root_process || strict_errors) {
 				res = lchown(pathname, i->uid, i->gid);
 				if(res == -1) {
 					EXIT_UNSQUASH_STRICT("create_inode: failed to change "


### PR DESCRIPTION
The first diff is a simple fix to a cache leak in an error path in unsquashfs, which could lead to deadlock waiting for a free cache entry. Hopefully not controversial.

The next two diffs scratch particular itches we have; I hope you will also find them of value.

We expect unsquashfs -strict-errors to create an exact replica of the original filesystem or die trying. However, no attempt was made to restore file permissions or ownership when running as non-root (even though non-root users might have CAP_CHOWN). The second diff thus tries to restore permissions/ownership even when non-root and fails on error (when in -strict-errors mode).

Finally, the thirs patch adds a -one-file-system option to mksquashfs akin to tar's --one-file-system. It is possible but very cumbersome to build exclusions to have the same effect, but this is a significant simplification for our use case and is a small and straightforward patch.