### PR TITLE
squashfs-tools: fix build failure against gcc-10

### DIFF
--- a/squashfs-tools/mksquashfs.h
+++ b/squashfs-tools/mksquashfs.h
@@ -143,7 +143,7 @@ struct append_file {
 #endif
 
 extern struct cache *reader_buffer, *fragment_buffer, *reserve_cache;
-struct cache *bwriter_buffer, *fwriter_buffer;
+extern struct cache *bwriter_buffer, *fwriter_buffer;
 extern struct queue *to_reader, *to_deflate, *to_writer, *from_writer,
 	*to_frag, *locked_fragment, *to_process_frag;
 extern struct append_file **file_mapping;


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
cc ... -o mksquashfs
ld: read_fs.o:(.bss+0x0):
  multiple definition of `fwriter_buffer'; mksquashfs.o:(.bss+0x400c90): first defined here
ld: read_fs.o:(.bss+0x8):
  multiple definition of `bwriter_buffer'; mksquashfs.o:(.bss+0x400c98): first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/706456