### PR TITLE
Fix compiling with -fno-common

### DIFF
--- a/squashfs-tools/mksquashfs.h
+++ b/squashfs-tools/mksquashfs.h
@@ -143,7 +143,7 @@ struct append_file {
 #endif
 
 extern struct cache *reader_buffer, *fragment_buffer, *reserve_cache;
-struct cache *bwriter_buffer, *fwriter_buffer;
+extern struct cache *bwriter_buffer, *fwriter_buffer;
 extern struct queue *to_reader, *to_deflate, *to_writer, *from_writer,
 	*to_frag, *locked_fragment, *to_process_frag;
 extern struct append_file **file_mapping;


### PR DESCRIPTION
GCC 10 will enable -fno-common by default[0], which causes the linker to fail like this [1]:

```
ld: read_fs.o:(.bss+0x0): multiple definition of `fwriter_buffer';
mksquashfs.o:(.bss+0x400c90): first defined here
ld: read_fs.o:(.bss+0x8): multiple definition of `bwriter_buffer';
mksquashfs.o:(.bss+0x400c98): first defined here
```

Fix this by declaring both variables as `extern` in the header file.

[0] https://gcc.gnu.org/gcc-10/porting_to.html#common
[1] https://bugs.gentoo.org/706456