### PR TITLE
pseudo: new mode to read directly from a file

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -3737,6 +3737,19 @@ void dir_scan2(struct dir_info *dir, struct pseudo *pseudo)
 				lookup_inode3(&buf, PSEUDO_FILE_OTHER, 0,
 				pseudo_ent->dev->symlink,
 				strlen(pseudo_ent->dev->symlink) + 1), dir);
+		} else if(pseudo_ent->dev->type == 'r') {
+			struct stat src;
+			if(lstat(pseudo_ent->dev->source_path, &src) == -1) {
+				ERROR_START("Cannot stat file %s because %s",
+					pseudo_ent->dev->source_path,
+					strerror(errno));
+				ERROR_EXIT(", skipping...\n");
+				continue;
+			}
+			buf.st_size = src.st_size;
+			add_dir_entry2(pseudo_ent->name, NULL,
+				pseudo_ent->dev->source_path, NULL,
+				lookup_inode2(&buf, PSEUDO_FILE_OTHER, 0), dir);
 		} else {
 			add_dir_entry2(pseudo_ent->name, NULL,
 				pseudo_ent->pathname, NULL,

--- a/squashfs-tools/pseudo.c
+++ b/squashfs-tools/pseudo.c
@@ -389,6 +389,7 @@ int read_pseudo_def(char *def)
 		}
 		break;
 	case 'f':
+	case 'r':
 		if(def[0] == '\0') {
 			ERROR("Not enough arguments in dynamic file pseudo "
 				"definition \"%s\"\n", orig_def);
@@ -465,6 +466,7 @@ int read_pseudo_def(char *def)
 		mode |= S_IFDIR;
 		break;
 	case 'f':
+	case 'r':
 		mode |= S_IFREG;
 		break;
 	case 's':
@@ -489,6 +491,8 @@ int read_pseudo_def(char *def)
 	}
 	if(type == 's')
 		dev->symlink = strdup(def);
+	if(type == 'r')
+		dev->source_path = strdup(def);
 
 	pseudo = add_pseudo(pseudo, dev, name, name);
 
@@ -502,6 +506,7 @@ error:
 	ERROR("\tfilename b mode uid gid major minor\n");
 	ERROR("\tfilename c mode uid gid major minor\n");
 	ERROR("\tfilename f mode uid gid command\n");
+	ERROR("\tfilename r mode uid gid command\n");
 	ERROR("\tfilename s mode uid gid symlink\n");
 	free(filename);
 	return FALSE;

--- a/squashfs-tools/pseudo.h
+++ b/squashfs-tools/pseudo.h
@@ -34,6 +34,7 @@ struct pseudo_dev {
 	union {
 		char		*command;
 		char		*symlink;
+		char		*source_path;
 	};
 };
 


### PR DESCRIPTION
This adds a new `r` mode, which is essentially an extention of `f`
but that reads file contents from an existing file rather than
executing a command, which can be significantly faster when
processing lots of files.

This is useful in cases where the an input file needs to be remapped
to another path inside the squashfs or have it's uid/gid/perms
changed.