### PR TITLE
squashfs-tools: Allow COMP_DEFAULT to be overridden via make cmdline

### DIFF
--- a/squashfs-tools/Makefile
+++ b/squashfs-tools/Makefile
@@ -85,7 +85,7 @@ GZIP_SUPPORT = 1
 # in Mksquashfs.  Obviously the compression algorithm must have been
 # selected to be built
 #
-COMP_DEFAULT = gzip
+COMP_DEFAULT ?= gzip
 
 
 ###############################################


### PR DESCRIPTION
Currently the only way to modify the default compression algorithm is to
modify the Makefile. It is useful to be able to set the default compression
algorithm via the make command line since otherwise a build time search
replace operation needs to be performed on the Makefile.

Signed-off-by: Peter Morrow <pemorrow@linux.microsoft.com>