### PR TITLE
Include endian.h before using __BYTE_ORDER  in squashfs_swap.h

### DIFF
--- a/squashfs-tools/squashfs_swap.h
+++ b/squashfs-tools/squashfs_swap.h
@@ -27,6 +27,14 @@
  * macros to convert each stucture from big endian to little endian
  */
 
+#ifndef linux
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#else
+#include <endian.h>
+#endif
+
 #if __BYTE_ORDER == __BIG_ENDIAN
 #include <stddef.h>
 extern void swap_le16(void *, void *);


### PR DESCRIPTION
Depending on the Linux distribution and compiler, the squashfs_swap.h file is included before endian.h, thus taking into consideration the code inside __BIG_ENDIAN `#if` even the system being little endian. A pratical reproduction of this problem is seen when compiling for Android. Including endian.h header ensures __BYTE_ORDER is defined before use and solves the issue.