### PR TITLE
Unsquashfs: fix always failing when build without xattr support

### DIFF
--- a/squashfs-tools/xattr.h
+++ b/squashfs-tools/xattr.h
@@ -112,7 +112,7 @@ static inline void restore_xattrs()
 
 static inline int write_xattr(char *pathname, unsigned int xattr)
 {
-	return 0;
+	return 1;
 }
 
 


### PR DESCRIPTION
`write_xattr` returns a boolean indicating success (TRUE/non-zero) or failure (FALSE/0).

The no-op implementation (`XATTR_SUPPORT=0`) always return 0 which is used as return value from `set_attributes` and treated as a failure in `writer` thread.

This patch just makes that "no-op `write_xattr`" is always successful.