### PR TITLE
unsquashfs: improved progress bar when stdout is not a terminal

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -2944,16 +2944,10 @@ void progress_bar(long long current, long long max, int columns)
 	if(!tty) {
 		static long long previous = -1;
 
-		/*
-		 * Updating much more frequently than this results in huge
-		 * log files.
-		 */
-		if((current % 100) != 0 && current != max)
+		/* Updating too frequently results in huge log files */
+		if(current * 100 / max == previous && current != max)
 			return;
-		/* Don't update just to rotate the spinner. */
-		if(current == previous)
-			return;
-		previous = current;
+		previous = current * 100 / max;
 	}
 
 	printf("\r[");


### PR DESCRIPTION
With this patch unsquashfs displays progress whenever percentage changes.
Before the progress was very irregular (for example 0% - 54% - 100%) and indeterministic (those numbers were different between different runs with the same inputs).

The cause is that the `progress_bar` function updates progress only if `current` is a multiple of 100.  However `current` counts both filesystem objects (regular files, symlinks, etc) *and* data blocks. Therefore `current` becomes a multiple of 100 very rarely (if ever), hence the problem.

Closes: #113