### PR TITLE
Avoid use of INSTALL_DIR for symlink targets

### DIFF
--- a/squashfs-tools/Makefile
+++ b/squashfs-tools/Makefile
@@ -406,5 +406,5 @@ install: mksquashfs unsquashfs
 	mkdir -p $(INSTALL_DIR)
 	cp mksquashfs $(INSTALL_DIR)
 	cp unsquashfs $(INSTALL_DIR)
-	ln -fs $(INSTALL_DIR)/unsquashfs $(INSTALL_DIR)/sqfscat
-	ln -fs $(INSTALL_DIR)/mksquashfs $(INSTALL_DIR)/sqfstar
+	ln -fs unsquashfs $(INSTALL_DIR)/sqfscat
+	ln -fs mksquashfs $(INSTALL_DIR)/sqfstar


### PR DESCRIPTION
In case INSTALL_DIR is overridden with a staged install location, using
INSTALL_DIR for the symlink target path prefix will yield an incorrect location
for the final installation.

Because the symlink itself is already installed to INSTALL_DIR, simply removing
the INSTALL_DIR prefix suffices as a fix.

Note that using $DESTDIR/$INSTALL_DIR where appropriate can avoid this type of
issue, but that can be considered a future enhancement.