### PR TITLE
Don't sanity check fragment table location if there are no fragments

### DIFF
--- a/squashfs-tools/unsquash-4.c
+++ b/squashfs-tools/unsquash-4.c
@@ -628,15 +628,6 @@ static int read_filesystem_tables()
 
 		if(read_fragment_table(&table_start) == FALSE)
 			goto corrupted;
-	} else {
-		/*
-		 * Sanity check super block contents - with 0 fragments,
-		 * the fragment table should be empty
-		 */
-		if(sBlk.s.fragment_table_start != table_start) {
-			ERROR("read_filesystem_tables: fragment table start invalid in super block\n");
-			goto corrupted;
-		}
 	}
 
 	/* Sanity check super block directory table values */


### PR DESCRIPTION
If there are no fragments (as per the super block fragment count),
the fragment table is not accessed. In that case, it makes no sense
to check the fragment table location or assume anything about it.
It could reasonably be set to e.g. SQUASHFS_INVALID_BLK like the
other fields, which trips this check.

Furthermore, the kernel side implementation also does not perform
this check if the fragment count is zero. So with this check in
place, `unsquashfs` is no longer able to unpack images that the
kernel happily accepts as valid.