### PR TITLE
Usage: clearly state that -nopad will make the image unmountable

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -242,7 +242,8 @@ Filesystem build options:
 -root-gid <gid>		set root directory group to <gid>
 -force-uid <uid>	set all file uids to <uid>
 -force-gid <gid>	set all file gids to <gid>
--nopad			do not pad filesystem to a multiple of 4K
+-nopad			do not pad filesystem to a multiple of 4K; padding is required for
+			using it on block devices. You will not be able to mount this image!
 -keep-as-directory	if one source directory is specified, create a root
 			directory containing that directory, rather than the
 			contents of the directory


### PR DESCRIPTION
Debian built its manpage for mksquashfs from this document, and other Linux
distributions copy/extend on that. Hopefully, adding this remark in the
command line options list will make this knowledge percolate to users.

Signed-off-by: Marcus Müller <marcus@hostalia.de>

----

This is an issue I've personally run across, and only after I've did quite some a/b testing I was able to search for the right term. That was admittedly not very clever, but more explicit documentation rarely hurts – and it would have helped me (I've only read the full USAGE file after my distro's manpage couldn't help me).