### PR TITLE
Avoid passing giant values to read/write

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -536,7 +536,7 @@ long long read_bytes(int fd, void *buff, long long bytes)
 	long long res, count;
 
 	for(count = 0; count < bytes; count += res) {
-		int len = (bytes - count) > SSIZE_MAX ? SSIZE_MAX : bytes - count;
+		size_t len = (bytes - count) > SSIZE_MAX ? SSIZE_MAX : bytes - count;
 
 		res = read(fd, buff + count, len);
 		if(res < 1) {
@@ -585,7 +585,7 @@ int write_bytes(int fd, void *buff, long long bytes)
 	long long res, count;
 
 	for(count = 0; count < bytes; count += res) {
-		int len = (bytes - count) > SSIZE_MAX ? SSIZE_MAX : bytes - count;
+		size_t len = (bytes - count) > SSIZE_MAX ? SSIZE_MAX : bytes - count;
 
 		res = write(fd, buff + count, len);
 		if(res == -1) {

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -623,7 +623,7 @@ int read_fs_bytes(int fd, long long byte, long long bytes, void *buff)
 	}
 
 	for(count = 0; count < bytes; count += res) {
-		int len = (bytes - count) > SSIZE_MAX ? SSIZE_MAX : bytes - count;
+		size_t len = (bytes - count) > SSIZE_MAX ? SSIZE_MAX : bytes - count;
 		res = read(fd, buff + count, len);
 		if(res < 1) {
 			if(res == 0) {


### PR DESCRIPTION
Avoid casting from `long long` to `int` before calling a function which takes `size_t`.

On a 64 bit system, In the case where `bytes - count == (long long)INT_MAX + 1`, this will not be `> SSIZE_MAX`, but when cast to `int`, it will become `INT_MIN`. When `INT_MIN` is cast to `size_t`, it becomes an enormous number (much greater than `SSIZE_MAX`, and much greater than `bytes - count`.

Perhaps worse, if `bytes - count == ((long long)INT_MAX + 1) * 2`, this will become 0 when cast to `int`. `read` will then return `0`, which we will treat as an early EOF.

In this case, because the overflow only occurs on values `> INT_MAX`, and these functions don't seem to be ever called with values so large, the change is largly academic, however, it has a side benefit of silencing an error when compiled with clang about casting `SSIZE_MAX` to `int` changing the value to `-1`

Closes #171 