### PR TITLE
Add option for skipping user xattrs.

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -75,6 +75,7 @@ long long cur_blocks = 0;
 int inode_number = 1;
 int no_xattrs = XATTR_DEF;
 int user_xattrs = FALSE;
+int ignore_user = FALSE;
 int ignore_errors = FALSE;
 int strict_errors = FALSE;
 int use_localtime = TRUE;
@@ -3814,6 +3815,7 @@ static void print_options(FILE *stream, char *name)
 	fprintf(stream, "\t-x[attrs]\t\textract xattrs in file system" XOPT_STR "\n");
 	fprintf(stream, "\t-u[ser-xattrs]\t\tonly extract user xattrs in file ");
 	fprintf(stream, "system.\n\t\t\t\tEnables extracting xattrs\n");
+        fprintf(stream, "\t-ignore-user[-xattrs]\tskip over user xattrs\n");
 	fprintf(stream, "\t-p[rocessors] <number>\tuse <number> processors.  ");
 	fprintf(stream, "By default will use\n");
 	fprintf(stream, "\t\t\t\tthe number of processors available\n");
@@ -4131,6 +4133,15 @@ int parse_options(int argc, char *argv[])
 					"this build\n", argv[0]);
 				exit(1);
 			}
+                } else if(strcmp(argv[i], "-ignore-user-xattrs") == 0 ||
+                                strcmp(argv[i], "-ignore-user") == 0) {
+                        if(xattrs_supported()) {
+				ignore_user = TRUE;
+                        } else {
+                                ERROR("%s: xattrs are unsupported in "
+                                        "this build\n", argv[0]);
+                                exit(1);
+                        }
 		} else if(strcmp(argv[i], "-dest") == 0 ||
 				strcmp(argv[i], "-d") == 0) {
 			if(++i == argc) {

--- a/squashfs-tools/unsquashfs_xattr.c
+++ b/squashfs-tools/unsquashfs_xattr.c
@@ -31,6 +31,7 @@
 
 extern int root_process;
 extern int user_xattrs;
+extern int ignore_user;
 extern int ignore_errors;
 extern int strict_errors;
 
@@ -61,7 +62,8 @@ int write_xattr(char *pathname, unsigned int xattr)
 	for(i = 0; i < count; i++) {
 		int prefix = xattr_list[i].type & SQUASHFS_XATTR_PREFIX_MASK;
 
-		if(ignore_xattrs || (user_xattrs && prefix != SQUASHFS_XATTR_USER))
+		if(ignore_xattrs || (user_xattrs && prefix != SQUASHFS_XATTR_USER) ||
+                                    (ignore_user && prefix == SQUASHFS_XATTR_USER))
 			continue;
 
 		if(root_process || prefix == SQUASHFS_XATTR_USER) {


### PR DESCRIPTION
On certain file systems, such as TMPFS, user
xattrs are not supported, which will cause
setxattr() to fail, and current unsquashfs
behavior will stop writing any xattrs from
that point on.

However, it may still be desirable to write
other xattrs, such as SELinux labels, which
are in the security namespace, which
may be supoorted (again, TMPFS).

Unpacking a live image to TMPFS for a
R/W filesystem is a very common operation,
and current unsquashfs code makes it impossible
to preserve SELinux labels if user xattrs are
also present.

This patch provides a parameter to skip
the user xattrs when unpacking the squashfs.