### PR TITLE
squashfs-tools: rework some function to POSIX standard

### DIFF
--- a/squashfs-tools/action.c
+++ b/squashfs-tools/action.c
@@ -2596,9 +2596,17 @@ static char *get_start(char *s, int n)
 
 static int subpathname_fn(struct atom *atom, struct action_data *action_data)
 {
-	return fnmatch(atom->argv[0], get_start(strdupa(action_data->subpath),
-		count_components(atom->argv[0])),
-		FNM_PATHNAME|FNM_EXTMATCH) == 0;
+	char *s, *tmp;
+	int ret;
+
+	s = tmp = strdup(action_data->subpath);
+	tmp = get_start(tmp, count_components(atom->argv[0]));
+
+	ret = fnmatch(atom->argv[0], tmp, FNM_PATHNAME|FNM_EXTMATCH);
+
+	free(s);
+
+	return ret == 0;
 }
 
 /*

--- a/squashfs-tools/info.c
+++ b/squashfs-tools/info.c
@@ -144,7 +144,7 @@ static void dump_state()
 static void *info_thrd(void *arg)
 {
 	sigset_t sigmask;
-	struct timespec timespec = { .tv_sec = 1, .tv_nsec = 0 };
+	struct timeval old_time = {0}, cur_time = {0};
 	int sig, waiting = 0;
 
 	sigemptyset(&sigmask);
@@ -152,25 +152,12 @@ static void *info_thrd(void *arg)
 	sigaddset(&sigmask, SIGHUP);
 
 	while(1) {
-		if(waiting)
-			sig = sigtimedwait(&sigmask, NULL, &timespec);
-		else
-			sig = sigwaitinfo(&sigmask, NULL);
+		sigwait(&sigmask, &sig);
 
-		if(sig == -1) {
-			switch(errno) {
-			case EAGAIN:
-				/* interval timed out */
+		if(waiting) {
+			gettimeofday(&cur_time, NULL);
+			if (cur_time.tv_sec > old_time.tv_sec )
 				waiting = 0;
-				/* FALLTHROUGH */
-			case EINTR:
-				/* if waiting, the wait will be longer, but
-				   that's OK */
-				continue;
-			default:
-				BAD_ERROR("sigtimedwait/sigwaitinfo failed "
-					"because %s\n", strerror(errno));
-			}
 		}
 
 		if(sig == SIGQUIT && !waiting) {
@@ -181,6 +168,8 @@ static void *info_thrd(void *arg)
 			waiting = 1;
 		} else
 			dump_state();
+
+		gettimeofday(&old_time, NULL);
 	}
 }
 


### PR DESCRIPTION
Some function are not POSIX and cause compilation error on MacOS (and I assume also other BSD based systems)

This try to rework the affected function while keeping the original implementation.