### PR TITLE
Unsquashfs: fix compilation error for missing sysctl.h on macos

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -36,7 +36,7 @@
 #include <sched.h>
 #include <sys/sysinfo.h>
 #include <sys/sysmacros.h>
-#elif defined __FreeBSD__
+#else
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
Currently the include of sys/sysctl.h is guarded and done only for FreeBSD system. Remove this to fix compilation error on macos following the same pattern done in mksquashfs.c

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>