### PR TITLE
xattr: fix out of bounds access (again)

### DIFF
--- a/squashfs-tools/xattr.c
+++ b/squashfs-tools/xattr.c
@@ -838,7 +838,7 @@ int read_xattrs(void *d, int type)
 	for(j = 1;  j < i; j++)
 		xattr_list[j - 1].vnext = &xattr_list[j];
 
-	xattr_list[j].vnext = NULL;
+	xattr_list[i - 1].vnext = NULL;
 	head = xattr_list;
 
 	sort_xattr_list(&head, i);


### PR DESCRIPTION
This restores the fix from c5db34e , which was somehow lost in 83b2f3a . `j` is not available after the loop is done, we need to use i. We use `i - 1` because, of course, list indexes start at 0.

Fixes https://github.com/plougher/squashfs-tools/issues/230