### PR TITLE
xattr: copy the name for later use

### DIFF
--- a/squashfs-tools/xattr.c
+++ b/squashfs-tools/xattr.c
@@ -219,6 +219,7 @@ static int read_xattrs_from_system(struct dir_ent *dir_ent, char *filename,
 		xattr_list = x;
 
 		xattr_list[i].type = xattr_get_prefix(&xattr_list[i], p);
+		xattr_list[i].full_name = strdup(p);
 		p += strlen(p) + 1;
 
 		if(xattr_list[i].type == -1) {


### PR DESCRIPTION
Commit 744ca24fd680eb0535b251e801be10195d2ffcfb changed to no longer copy the name, but we need it. Copy it here.

Fixes #234