### PR TITLE
Mksquashfs: add option to allow compression early abort

### DIFF
--- a/squashfs-tools/compressor.c
+++ b/squashfs-tools/compressor.c
@@ -25,6 +25,11 @@
 #include "compressor.h"
 #include "squashfs_fs.h"
 
+#ifdef ZSTD_SUPPORT
+#include <zstd.h>
+#include <zstd_errors.h>
+#endif
+
 #ifndef GZIP_SUPPORT
 static struct compressor gzip_comp_ops =  {
 	ZLIB_COMPRESSION, "gzip"
@@ -142,4 +147,17 @@ void display_compressor_usage(FILE *stream, char *def_comp)
 				fprintf(stream, "\t%s (no options)%s\n",
 					compressor[i]->name, str);
 		}
+}
+
+
+int is_compressible(const void *in, int size, void *out, int outsize) {
+#ifndef ZSTD_SUPPORT
+	return 1;
+#else
+	size_t ret = ZSTD_compress(out, outsize, in, size, 1);
+	if (ZSTD_isError(ret)) {
+		return 0;
+	}
+	return ret < size;
+#endif
 }

--- a/squashfs-tools/compressor.h
+++ b/squashfs-tools/compressor.h
@@ -129,4 +129,9 @@ static inline int compressor_option_args(struct compressor *comp, char *option)
 		return 0;
 	return comp->option_args(option);
 }
+
+
+int is_compressible(const void *in, int size, void *out, int outsize);
+
+
 #endif


### PR DESCRIPTION
Introduce a command line option (-comp-early-abort) to enable block-based early abort of compression for incompressible data, improving efficiency.

The compressibility test is done by using Zstd level 1, so this feature is dependent on Zstd support.

This is about https://github.com/plougher/squashfs-tools/issues/240.