### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/squashfs-tools/action.c
+++ b/squashfs-tools/action.c
@@ -38,6 +38,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <ctype.h>
+#include <pthread.h>
 
 #include "squashfs_fs.h"
 #include "mksquashfs.h"

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -48,6 +48,7 @@
 #include <sys/wait.h>
 #include <limits.h>
 #include <ctype.h>
+#include <pthread.h>
 
 #ifdef __linux__
 #include <sys/sysinfo.h>

--- a/squashfs-tools/pseudo.c
+++ b/squashfs-tools/pseudo.c
@@ -39,6 +39,7 @@
 #include <regex.h>
 #include <dirent.h>
 #include <sys/types.h>
+#include <pthread.h>
 
 #include "pseudo.h"
 #include "mksquashfs_error.h"

--- a/squashfs-tools/read_fs.c
+++ b/squashfs-tools/read_fs.c
@@ -36,6 +36,7 @@
 #include <dirent.h>
 #include <stdlib.h>
 #include <regex.h>
+#include <pthread.h>
 
 #include "squashfs_fs.h"
 #include "squashfs_swap.h"

--- a/squashfs-tools/signals.h
+++ b/squashfs-tools/signals.h
@@ -28,7 +28,7 @@ static inline int wait_for_signal(sigset_t *sigmask, int *waiting)
 {
 	int sig;
 
-#if defined(__APPLE__) && defined(__MACH__)
+#ifndef __linux__
 	sigwait(sigmask, &sig);
 	*waiting = 0;
 #else

--- a/squashfs-tools/sort.c
+++ b/squashfs-tools/sort.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <pthread.h>
 
 #include "squashfs_fs.h"
 #include "mksquashfs.h"

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -32,6 +32,7 @@
 #include <grp.h>
 #include <time.h>
 #include <regex.h>
+#include <pthread.h>
 
 #include "squashfs_fs.h"
 #include "mksquashfs.h"

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -2788,6 +2788,8 @@ void initialise_threads(int fragment_buffer_size, int data_buffer_size, int cat_
 			processors = sysconf(_SC_NPROCESSORS_ONLN);
 		else
 			processors = CPU_COUNT(&cpu_set);
+#elif defined(__OpenBSD__)
+		processors = sysconf(_SC_NPROCESSORS_ONLN);
 #else
 		int mib[2];
 		size_t len = sizeof(processors);

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -3603,7 +3603,7 @@ void pseudo_print(char *pathname, struct inode *inode, char *link, long long off
 	else if(res >= 12)
 		EXIT_UNSQUASH("snprintf returned more than 11 digits in pseudo_print()\n");
 
-	res = dprintf(writer_fd, "%s %c %ld %o %s %s", filename, type, inode->time, inode->mode & ~S_IFMT, userstr, groupstr);
+	res = dprintf(writer_fd, "%s %c %lld %o %s %s", filename, type, (long long)inode->time, inode->mode & ~S_IFMT, userstr, groupstr);
 	if(res == -1)
 		EXIT_UNSQUASH("Failed to write to pseudo output file\n");
 


### PR DESCRIPTION
While I tested these changes briefly, I'm unsure if they do not have edge cases. Especially the patches provided by [OpenBSD-ports](https://github.com/openbsd/ports/tree/master/sysutils/squashfs-tools/patches) make use of SIGALRM to add timeouts to wait. I'm not sure if this behavior is desired, so I left it out for now.