### PR TITLE
Unsquashfs: ability to unpack over existing mount points

### DIFF
--- a/manpages/unsquashfs.1
+++ b/manpages/unsquashfs.1
@@ -58,6 +58,9 @@ set all file timestamps to TIME, rather than the time stored in the filesystem i
 \fB\-cat\fR
 cat the files on the command line to stdout.
 .TP
+\fB\-one\-file\-system\fR
+do not cross filesystem boundaries.  If a directory is an existing mount point, just skip it.
+.TP
 \fB\-f\fR, \fB\-force\fR
 if file already exists then overwrite.
 .TP


### PR DESCRIPTION
Changes the default behavior when unpacking a filesystem over pre-mounted directories. To return the default behavior, it is suggested to use the -one-file-system option, similar to mksquashfs.