### PR TITLE
squashfs support for uuid and label

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -7569,6 +7569,7 @@ print_sqfstar_compressor_options:
 			SQUASHFS_MAJOR, SQUASHFS_MINOR,
 			destination_file, block_size);
 
+	bytes = sizeof(struct squashfs_super_block);
 	/*
 	 * store any compressor specific options after the superblock,
 	 * and set the COMP_OPT flag to show that the filesystem has
@@ -7582,11 +7583,9 @@ print_sqfstar_compressor_options:
 			sizeof(c_byte), &c_byte);
 		write_destination(fd, sizeof(struct squashfs_super_block) +
 			sizeof(c_byte), size, comp_data);
-		bytes = sizeof(struct squashfs_super_block) + sizeof(c_byte)
-			+ size;
+		bytes += sizeof(c_byte) + size;
 		comp_opts = TRUE;
-	} else
-		bytes = sizeof(struct squashfs_super_block);
+	}
 
 	if(path)
 		paths = add_subdir(paths, path);
@@ -8703,6 +8702,7 @@ print_compressor_options:
 				SQUASHFS_MAJOR, SQUASHFS_MINOR,
 				destination_file, block_size);
 
+		bytes = sizeof(struct squashfs_super_block);
 		/*
 		 * store any compressor specific options after the superblock,
 		 * and set the COMP_OPT flag to show that the filesystem has
@@ -8716,11 +8716,9 @@ print_compressor_options:
 				sizeof(c_byte), &c_byte);
 			write_destination(fd, sizeof(struct squashfs_super_block) +
 				sizeof(c_byte), size, comp_data);
-			bytes = sizeof(struct squashfs_super_block) + sizeof(c_byte)
-				+ size;
+			bytes += sizeof(c_byte)	+ size;
 			comp_opts = TRUE;
-		} else			
-			bytes = sizeof(struct squashfs_super_block);
+		}
 	} else {
 		unsigned int last_directory_block, inode_dir_file_size,
 			root_inode_size, inode_dir_start_block,

--- a/squashfs-tools/squashfs_fs.h
+++ b/squashfs-tools/squashfs_fs.h
@@ -72,6 +72,7 @@
 #define SQUASHFS_NO_XATTR		9
 #define SQUASHFS_COMP_OPT		10
 #define SQUASHFS_NOID			11
+#define SQUASHFS_INFO			12
 
 #define SQUASHFS_BIT(flag, bit)		((flag >> bit) & 1)
 
@@ -108,12 +109,16 @@
 #define SQUASHFS_UNCOMPRESSED_IDS(flags)	SQUASHFS_BIT(flags, \
 						SQUASHFS_NOID)
 
+#define SQUASHFS_EXTRA_INFO(flags)		SQUASHFS_BIT(flags, \
+						SQUASHFS_INFO)
+
 #define SQUASHFS_MKFLAGS(noi, nod, nof, nox, noid, no_frag, always_frag, \
-		duplicate_checking, exportable, no_xattr, comp_opt) (noi | \
+		duplicate_checking, exportable, no_xattr, comp_opt, \
+		extra_info) (noi | \
 		(nod << 1) | (nof << 3) | (no_frag << 4) | \
 		(always_frag << 5) | (duplicate_checking << 6) | \
 		(exportable << 7) | (nox << 8) | (no_xattr << 9) | \
-		(comp_opt << 10) | (noid << 11))
+		(comp_opt << 10) | (noid << 11) | (extra_info << 12))
 
 /* Max number of types and file types */
 #define SQUASHFS_DIR_TYPE		1
@@ -288,6 +293,10 @@ typedef long long		squashfs_inode;
 #define XZ_COMPRESSION		4
 #define LZ4_COMPRESSION		5
 #define ZSTD_COMPRESSION	6
+
+#define SQUASHFS_EXTRA_INFO_TAG_END   0
+#define SQUASHFS_EXTRA_INFO_TAG_LABEL 1
+#define SQUASHFS_EXTRA_INFO_TAG_UUID  2
 
 struct squashfs_super_block {
 	unsigned int		s_magic;


### PR DESCRIPTION
Here's working code for #59, the basics of which I've reimplemented a few times over the years.

Curious what @plougher thinks about this approach.

Due to the way squashfs directly stores the offsets to the datablocks and fragments, and the remaining sections having offsets stored in the superblock... no squashfs-mount/unsquashfs/etc implementation ever bothers to precisely parse the compressions option metablock nor expects the datablocks to start at the byte after that metablock.

As such, it has proved to be perfectly backwards compatible wherever I've used it.

See https://github.com/plougher/squashfs-tools/issues/59#issuecomment-1710941443 for how it is used, behaves, and how to build it (and the corresponding changes to libblkid)

Let me know if this approach (or something similar) has a chance of being merged upstream.

Only after the above question is answered... here are some preemptive comments for other things to think about before considering merging:
- Allow dependency on _libuuid_? (so we can internally generate random uuids when desired without a shell call to _uuidgen_)
- Add support for _sqfstar_ equivalents, update docs, etc.
- What is the desired _-append_ behavior w/ uuid/labels?
- Talk about ability to add/remove a uuid/label from an existing squashfs (that has or doesn't have an existing uuid/label).
