### PR TITLE
add tailsize_range(min,max) to doc.

### DIFF
--- a/ACTIONS-README
+++ b/ACTIONS-README
@@ -248,6 +248,12 @@ Returns FALSE on anything not a directory.
 Return TRUE if the size of the file is within the range [<minimum>, <maximum>]
 inclusive.  Returns FALSE on anything not a file.
 
+4.18.1 tailsize_range(minimum, maximum)
+-------------------------------------
+
+Return TRUE if the size of tail end of the file is within the range
+[<minimum>, <maximum>] inclusive.  Returns FALSE on anything not a file.
+
 4.19 dirsize_range(minimum, maximum)
 ------------------------------------
 


### PR DESCRIPTION
When I requested pulling tailsize(), I did copy-and-paste code of tailsize_range() with misunderstanding it were part of tailsize().
https://github.com/plougher/squashfs-tools/pull/266
But later, I noticed there is filesize_range() test action documented apart from filesize().
This pull request is to remove this inconsistency by adding tailsize_range() to document.
Sorry for previous half-baked one.