### PR TITLE
Add ARM64 filter support

### DIFF
--- a/squashfs-tools/xz_wrapper.c
+++ b/squashfs-tools/xz_wrapper.c
@@ -38,6 +38,9 @@ static struct bcj bcj[] = {
 	{ "arm", LZMA_FILTER_ARM, 0 },
 	{ "armthumb", LZMA_FILTER_ARMTHUMB, 0 },
 	{ "sparc", LZMA_FILTER_SPARC, 0 },
+#ifdef LZMA_FILTER_ARM64
+	{ "arm64", LZMA_FILTER_ARM64, 0 },
+#endif
 	{ NULL, LZMA_VLI_UNKNOWN, 0 }
 };
 
@@ -451,6 +454,13 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 
 		stream->opt.dict_size = stream->dictionary_size;
 
+#ifdef LZMA_FILTER_ARM64
+		if(filter->filter[0].id == LZMA_FILTER_ARM64) {
+			stream->opt.lp = 2;
+			stream->opt.lc = 2;
+		}
+#endif
+
 		filter->length = 0;
 		res = lzma_stream_buffer_encode(filter->filter,
 			LZMA_CHECK_CRC32, NULL, src, size, filter->buffer,
@@ -509,8 +519,8 @@ static void xz_usage(FILE *stream)
 	fprintf(stream, "\t\tCompress using filter1,filter2,...,filterN in");
 	fprintf(stream, " turn\n\t\t(in addition to no filter), and choose");
 	fprintf(stream, " the best compression.\n");
-	fprintf(stream, "\t\tAvailable filters: x86, arm, armthumb,");
-	fprintf(stream, " powerpc, sparc, ia64\n");
+	fprintf(stream, "\t\tAvailable filters: x86, arm, armthumb, arm64,");
+	fprintf(stream, " powerpc, sparc,\n\t\tia64\n");
 	fprintf(stream, "\t  -Xdict-size <dict-size>\n");
 	fprintf(stream, "\t\tUse <dict-size> as the XZ dictionary size.  The");
 	fprintf(stream, " dictionary size\n\t\tcan be specified as a");

--- a/squashfs-tools/xz_wrapper_extended.c
+++ b/squashfs-tools/xz_wrapper_extended.c
@@ -40,6 +40,9 @@ static struct bcj bcj[] = {
 	{ "arm", LZMA_FILTER_ARM, 0 },
 	{ "armthumb", LZMA_FILTER_ARMTHUMB, 0 },
 	{ "sparc", LZMA_FILTER_SPARC, 0 },
+#ifdef LZMA_FILTER_ARM64
+	{ "arm64", LZMA_FILTER_ARM64, 0 },
+#endif
 	{ NULL, LZMA_VLI_UNKNOWN, 0 }
 };
 
@@ -540,6 +543,13 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 
 		stream->opt.dict_size = stream->dictionary_size;
 
+#ifdef LZMA_FILTER_ARM64
+		if(filter->filter[0].id == LZMA_FILTER_ARM64) {
+			stream->opt.lp = 2;
+			stream->opt.lc = 2;
+		}
+#endif
+
 		if (lc >= 0)
 			stream->opt.lc = lc;
 
@@ -607,8 +617,8 @@ static void xz_usage(FILE *stream)
 	fprintf(stream, "\t\tCompress using filter1,filter2,...,filterN in");
 	fprintf(stream, " turn\n\t\t(in addition to no filter), and choose");
 	fprintf(stream, " the best compression.\n");
-	fprintf(stream, "\t\tAvailable filters: x86, arm, armthumb,");
-	fprintf(stream, " powerpc, sparc, ia64\n");
+	fprintf(stream, "\t\tAvailable filters: x86, arm, armthumb, arm64,");
+	fprintf(stream, " powerpc, sparc,\n\t\tia64\n");
 	fprintf(stream, "\t  -Xdict-size <dict-size>\n");
 	fprintf(stream, "\t\tUse <dict-size> as the XZ dictionary size.  The");
 	fprintf(stream, " dictionary size\n\t\tcan be specified as a");


### PR DESCRIPTION
This sets LZMA2 options pb=2, lp=2, lc=2 as the default with the ARM64 filter as those are good for ARM64 code (all instructions are 4 bytes and 4-byte aligned). pb=2 is a default from the preset. lc=2 is needed because the sum lc+lp must not exceed 4 and the default is lc=3.

The ARM64 filter requires liblzma >= 5.4.0. It will build against older liblzma but then the filter won't be available. An alternative could have been to use

    #ifndef LZMA_FILTER_ARM64
    #define LZMA_FILTER_ARM64 LZMA_VLI_C(0x0A)
    #endif

which would allow building against older liblzma and make the filter available once liblzma is upgraded, without requiring a recompilation of squashfs-tools.

The help text lists `arm64` even if built against pre-5.4.0.

Linux 6.7 will hopefully include the ARM64 filter.
https://lkml.org/lkml/2023/11/8/775