### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/squashfs-tools/mksquashfs.h
+++ b/squashfs-tools/mksquashfs.h
@@ -24,6 +24,7 @@
  * mksquashfs.h
  *
  */
+#include <pthread.h>
 
 struct dir_info {
 	char			*pathname;

--- a/squashfs-tools/signals.h
+++ b/squashfs-tools/signals.h
@@ -28,7 +28,7 @@ static inline int wait_for_signal(sigset_t *sigmask, int *waiting)
 {
 	int sig;
 
-#if defined(__APPLE__) && defined(__MACH__)
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__OpenBSD__)
 	sigwait(sigmask, &sig);
 	*waiting = 0;
 #else

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -1232,7 +1232,11 @@ int create_inode(char *pathname, struct inode *i)
 			break;
 		case SQUASHFS_SYMLINK_TYPE:
 		case SQUASHFS_LSYMLINK_TYPE: {
+#ifdef __OpenBSD__
+			struct timespec times[2] = {
+#else
 			struct timeval times[2] = {
+#endif
 				{ i->time, 0 },
 				{ i->time, 0 }
 			};
@@ -1251,7 +1255,11 @@ int create_inode(char *pathname, struct inode *i)
 				goto failed;
 			}
 
+#ifdef __OpenBSD__
+			res = utimensat(AT_FDCWD, pathname, times, AT_SYMLINK_NOFOLLOW);
+#else
 			res = lutimes(pathname, times);
+#endif
 			if(res == -1) {
 				EXIT_UNSQUASH_STRICT("create_inode: failed to"
 					" set time on %s, because %s\n",


### PR DESCRIPTION
- it lacks sigtimedwait(2) and sigwaitinfo(2) just like Darwin
- there is no lutimes(2) but we can emulate it with utimensat(2)
- squashfs-tools/mksquashfs.h references pthread_mutex_t so include the header for it