### PR TITLE
Add RISC-V filter support

### DIFF
--- a/squashfs-tools/xz_wrapper.c
+++ b/squashfs-tools/xz_wrapper.c
@@ -41,6 +41,9 @@ static struct bcj bcj[] = {
 #ifdef LZMA_FILTER_ARM64
 	{ "arm64", LZMA_FILTER_ARM64, 0 },
 #endif
+#ifdef LZMA_FILTER_RISCV
+	{ "riscv", LZMA_FILTER_RISCV, 0 },
+#endif
 	{ NULL, LZMA_VLI_UNKNOWN, 0 }
 };
 
@@ -461,6 +464,11 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 		}
 #endif
 
+#ifdef LZMA_FILTER_RISCV
+		if(filter->filter[0].id == LZMA_FILTER_RISCV)
+			stream->opt.lp = 1;
+#endif
+
 		filter->length = 0;
 		res = lzma_stream_buffer_encode(filter->filter,
 			LZMA_CHECK_CRC32, NULL, src, size, filter->buffer,
@@ -520,7 +528,7 @@ static void xz_usage(FILE *stream)
 	fprintf(stream, " turn\n\t\t(in addition to no filter), and choose");
 	fprintf(stream, " the best compression.\n");
 	fprintf(stream, "\t\tAvailable filters: x86, arm, armthumb, arm64,");
-	fprintf(stream, " powerpc, sparc,\n\t\tia64\n");
+	fprintf(stream, " powerpc, sparc,\n\t\tia64, riscv\n");
 	fprintf(stream, "\t  -Xdict-size <dict-size>\n");
 	fprintf(stream, "\t\tUse <dict-size> as the XZ dictionary size.  The");
 	fprintf(stream, " dictionary size\n\t\tcan be specified as a");

--- a/squashfs-tools/xz_wrapper_extended.c
+++ b/squashfs-tools/xz_wrapper_extended.c
@@ -43,6 +43,9 @@ static struct bcj bcj[] = {
 #ifdef LZMA_FILTER_ARM64
 	{ "arm64", LZMA_FILTER_ARM64, 0 },
 #endif
+#ifdef LZMA_FILTER_RISCV
+	{ "riscv", LZMA_FILTER_RISCV, 0 },
+#endif
 	{ NULL, LZMA_VLI_UNKNOWN, 0 }
 };
 
@@ -550,6 +553,11 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 		}
 #endif
 
+#ifdef LZMA_FILTER_RISCV
+		if(filter->filter[0].id == LZMA_FILTER_RISCV)
+			stream->opt.lp = 1;
+#endif
+
 		if (lc >= 0)
 			stream->opt.lc = lc;
 
@@ -618,7 +626,7 @@ static void xz_usage(FILE *stream)
 	fprintf(stream, " turn\n\t\t(in addition to no filter), and choose");
 	fprintf(stream, " the best compression.\n");
 	fprintf(stream, "\t\tAvailable filters: x86, arm, armthumb, arm64,");
-	fprintf(stream, " powerpc, sparc,\n\t\tia64\n");
+	fprintf(stream, " powerpc, sparc,\n\t\tia64, riscv\n");
 	fprintf(stream, "\t  -Xdict-size <dict-size>\n");
 	fprintf(stream, "\t\tUse <dict-size> as the XZ dictionary size.  The");
 	fprintf(stream, " dictionary size\n\t\tcan be specified as a");


### PR DESCRIPTION
This requires liblzma >= 5.6.0. The LZMA2 options are set with the assumption that the RISC-V C extension is in use.

I have [submitted the RISC-V filter to Linux](https://lore.kernel.org/lkml/20240320183846.19475-10-lasse.collin@tukaani.org/). It's in [the -mm mm-nonmm-unstable branch](https://git.kernel.org/pub/scm/linux/kernel/git/akpm/mm.git/log/?h=mm-nonmm-unstable) at the moment.

The ARM64 filter is there too, that is, it didn't get into Linux 6.7 or 6.8. I failed to ensure that it would get included. Sorry.

(Not about this PR but it could be good if the default LZMA2 options could be changed for the old filters too: ARM, PowerPC, and SPARC would use the same as ARM64, and ARM-Thumb the same as RISC-V. IA-64 would need pb=4,lp=4,lc=0 but the IA-64 filter [was disabled in Linux 6.7](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/lib/xz/Kconfig?id=cf8e8658100d4eae80ce9b21f7a81cb024dd5057), possibly by accident, when support for the IA-64 arch was removed.)