### PR TITLE
mksquashfs: remove old reference to phys_mem

### DIFF
--- a/squashfs-tools/memory_compat.h
+++ b/squashfs-tools/memory_compat.h
@@ -64,7 +64,7 @@ static inline int get_physical_memory()
 	if(num_pages == -1 || page_size == -1)
 		return 0;
 	else
-		return phys_mem = num_pages * page_size >> 20;
+		return num_pages * page_size >> 20;
 }
 #endif
 #endif


### PR DESCRIPTION
I think it was left over after a509bba0c15b3bac4257eb42cf3ade518a6d5c77 