### PR TITLE
XZ: Support ARM64 and RISC-V filters

### DIFF
--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -17,7 +17,7 @@ during the long development process of Squashfs 4.3.
 Acknowledgements for Squashfs 4.2
 ---------------------------------
 
-Thanks to Lasse Collin (http://tukaani.org/xz/) for mainlining XZ
+Thanks to Lasse Collin (https://tukaani.org/xz/) for mainlining XZ
 decompression support.
 
 Acknowledgements for Squashfs 4.1

--- a/squashfs-tools/Makefile
+++ b/squashfs-tools/Makefile
@@ -25,7 +25,7 @@ GZIP_SUPPORT = 1
 #
 # LZMA2 compression.
 #
-# XZ Utils liblzma (http://tukaani.org/xz/) is supported
+# XZ Utils liblzma (https://tukaani.org/xz/) is supported
 #
 # Development packages (libraries and header files) should be
 # supported by most modern distributions.  Please refer to
@@ -178,7 +178,7 @@ INSTALL_MANPAGES_DIR = $(INSTALL_PREFIX)/man/man1
 # LZMA1 compression is obsolete, and the newer and better XZ (LZMA2)
 # compression should be used in preference.
 #
-# Both XZ Utils liblzma (http://tukaani.org/xz/) and LZMA SDK
+# Both XZ Utils liblzma (https://tukaani.org/xz/) and LZMA SDK
 # (http://www.7-zip.org/sdk.html) are supported
 #
 # To build using XZ Utils liblzma - install the library and uncomment

--- a/squashfs-tools/lzma_xz_wrapper.c
+++ b/squashfs-tools/lzma_xz_wrapper.c
@@ -18,7 +18,7 @@
  *
  * lzma_xz_wrapper.c
  *
- * Support for LZMA1 compression using XZ Utils liblzma http://tukaani.org/xz/
+ * Support for LZMA1 compression using XZ Utils liblzma https://tukaani.org/xz/
  */
 
 #include <stdio.h>

--- a/squashfs-tools/xz_wrapper.c
+++ b/squashfs-tools/xz_wrapper.c
@@ -476,15 +476,26 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 		stream->opt.dict_size = stream->dictionary_size;
 
 		switch(filter->filter[0].id) {
+		case LZMA_FILTER_ARMTHUMB:
 		case LZMA_FILTER_RISCV:
 			/* 2-byte-aligned instructions */
 			stream->opt.lp = 1;
 			break;
 
+		case LZMA_FILTER_POWERPC:
+		case LZMA_FILTER_ARM:
+		case LZMA_FILTER_SPARC:
 		case LZMA_FILTER_ARM64:
 			/* 4-byte-aligned instructions */
 			stream->opt.lp = 2;
 			stream->opt.lc = 2;
+			break;
+
+		case LZMA_FILTER_IA64:
+			/* 16-byte-aligned instructions */
+			stream->opt.pb = 4;
+			stream->opt.lp = 4;
+			stream->opt.lc = 0;
 			break;
 		}
 

--- a/squashfs-tools/xz_wrapper.c
+++ b/squashfs-tools/xz_wrapper.c
@@ -97,6 +97,12 @@ static int xz_options(char *argv[], int argc)
 					"filter\n");
 				goto failed;
 			}
+			if(!lzma_filter_encoder_is_supported(bcj[i].id)) {
+				fprintf(stderr, "xz: -Xbcj %s: This filter "
+					"is not supported by the liblzma "
+					"version in use\n", bcj[i].name);
+				goto failed;
+			}
 		}
 
 		return 1;

--- a/squashfs-tools/xz_wrapper.c
+++ b/squashfs-tools/xz_wrapper.c
@@ -19,7 +19,7 @@
  * xz_wrapper.c
  *
  * Support for XZ (LZMA2) compression using XZ Utils liblzma
- * http://tukaani.org/xz/
+ * https://tukaani.org/xz/
  */
 
 #include <stdio.h>

--- a/squashfs-tools/xz_wrapper.c
+++ b/squashfs-tools/xz_wrapper.c
@@ -85,7 +85,7 @@ static int xz_options(char *argv[], int argc)
 						(name[n] == '\0' ||
 						 name[n] == ',')) {
 					if(bcj[i].selected == 0) {
-				 		bcj[i].selected = 1;
+						bcj[i].selected = 1;
 						filter_count++;
 					}
 					name += name[n] == ',' ? n + 1 : n;
@@ -98,7 +98,7 @@ static int xz_options(char *argv[], int argc)
 				goto failed;
 			}
 		}
-	
+
 		return 1;
 	} else if(strcmp(argv[0], "-Xdict-size") == 0) {
 		char *b;
@@ -145,7 +145,7 @@ static int xz_options(char *argv[], int argc)
 	}
 
 	return -1;
-	
+
 failed:
 	return -2;
 }
@@ -189,9 +189,9 @@ static int xz_options_post(int block_size)
 		/*
 		 * dictionary_size must be storable in xz header as either
 		 * 2^n or as  2^n+2^(n+1)
-	 	*/
+		 */
 		n = ffs(dictionary_size) - 1;
-		if(dictionary_size != (1 << n) && 
+		if(dictionary_size != (1 << n) &&
 				dictionary_size != ((1 << n) + (1 << (n + 1)))) {
 			fprintf(stderr, "xz: -Xdict-size is an unsupported "
 				"value, dict-size must be storable in xz "
@@ -288,7 +288,7 @@ static int xz_extract_options(int block_size, void *buffer, int size)
 		/* check passed comp opts struct is of the correct length */
 		if(size != sizeof(struct comp_opts))
 			goto failed;
-					 
+
 		SQUASHFS_INSWAP_COMP_OPTS(comp_opts);
 
 		dictionary_size = comp_opts->dictionary_size;
@@ -299,7 +299,7 @@ static int xz_extract_options(int block_size, void *buffer, int size)
 		 * size should 2^n or 2^n+2^(n+1)
 		 */
 		n = ffs(dictionary_size) - 1;
-		if(dictionary_size != (1 << n) && 
+		if(dictionary_size != (1 << n) &&
 				dictionary_size != ((1 << n) + (1 << (n + 1))))
 			goto failed;
 	}
@@ -343,7 +343,7 @@ static void xz_display_options(void *buffer, int size)
 	 * size should 2^n or 2^n+2^(n+1)
 	 */
 	n = ffs(dictionary_size) - 1;
-	if(dictionary_size != (1 << n) && 
+	if(dictionary_size != (1 << n) &&
 			dictionary_size != ((1 << n) + (1 << (n + 1))))
 		goto failed;
 
@@ -371,7 +371,7 @@ static void xz_display_options(void *buffer, int size)
 failed:
 	fprintf(stderr, "xz: error reading stored compressor options from "
 		"filesystem!\n");
-}	
+}
 
 
 /*
@@ -456,7 +456,7 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 		res = lzma_stream_buffer_encode(filter->filter,
 			LZMA_CHECK_CRC32, NULL, src, size, filter->buffer,
 			&filter->length, block_size);
-	
+
 		if(res == LZMA_OK) {
 			if(!selected || selected->length > filter->length)
 				selected = filter;
@@ -466,8 +466,8 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 
 	if(!selected)
 		/*
-	 	 * Output buffer overflow.  Return out of buffer space
-	 	 */
+		 * Output buffer overflow.  Return out of buffer space
+		 */
 		return 0;
 
 	if(selected->buffer != dest)

--- a/squashfs-tools/xz_wrapper.c
+++ b/squashfs-tools/xz_wrapper.c
@@ -32,6 +32,14 @@
 #include "compressor.h"
 #include "print_pager.h"
 
+/*
+ * ARM64 filter was added in liblzma 5.4.0. Keep the build working with
+ * older versions too.
+ */
+#ifndef LZMA_FILTER_ARM64
+#define LZMA_FILTER_ARM64 LZMA_VLI_C(0x0A)
+#endif
+
 static struct bcj bcj[] = {
 	{ "x86", LZMA_FILTER_X86, 0 },
 	{ "powerpc", LZMA_FILTER_POWERPC, 0 },
@@ -39,6 +47,7 @@ static struct bcj bcj[] = {
 	{ "arm", LZMA_FILTER_ARM, 0 },
 	{ "armthumb", LZMA_FILTER_ARMTHUMB, 0 },
 	{ "sparc", LZMA_FILTER_SPARC, 0 },
+	{ "arm64", LZMA_FILTER_ARM64, 0 },
 	{ NULL, LZMA_VLI_UNKNOWN, 0 }
 };
 
@@ -458,6 +467,14 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 
 		stream->opt.dict_size = stream->dictionary_size;
 
+		switch(filter->filter[0].id) {
+		case LZMA_FILTER_ARM64:
+			/* 4-byte-aligned instructions */
+			stream->opt.lp = 2;
+			stream->opt.lc = 2;
+			break;
+		}
+
 		filter->length = 0;
 		res = lzma_stream_buffer_encode(filter->filter,
 			LZMA_CHECK_CRC32, NULL, src, size, filter->buffer,
@@ -515,8 +532,8 @@ static void xz_usage(FILE *stream, int cols)
 	autowrap_print(stream, "\t  -Xbcj filter1,filter2,...,filterN\n", cols);
 	autowrap_print(stream, "\t\tCompress using filter1,filter2,...,filterN "
 		"in turn (in addition to no filter), and choose the best "
-		"compression.  Available filters: x86, arm, armthumb, powerpc, "
-		"sparc, ia64\n", cols);
+		"compression.  Available filters: x86, arm, armthumb, arm64, "
+		"powerpc, sparc, ia64\n", cols);
 	autowrap_print(stream, "\t  -Xdict-size <dict-size>\n", cols);
 	autowrap_print(stream, "\t\tUse <dict-size> as the XZ dictionary size."
 		"  The dictionary size can be specified as a percentage of the "

--- a/squashfs-tools/xz_wrapper.c
+++ b/squashfs-tools/xz_wrapper.c
@@ -40,6 +40,13 @@
 #define LZMA_FILTER_ARM64 LZMA_VLI_C(0x0A)
 #endif
 
+/*
+ * RISC-V filter was added in liblzma 5.6.0.
+ */
+#ifndef LZMA_FILTER_RISCV
+#define LZMA_FILTER_RISCV LZMA_VLI_C(0x0B)
+#endif
+
 static struct bcj bcj[] = {
 	{ "x86", LZMA_FILTER_X86, 0 },
 	{ "powerpc", LZMA_FILTER_POWERPC, 0 },
@@ -48,6 +55,7 @@ static struct bcj bcj[] = {
 	{ "armthumb", LZMA_FILTER_ARMTHUMB, 0 },
 	{ "sparc", LZMA_FILTER_SPARC, 0 },
 	{ "arm64", LZMA_FILTER_ARM64, 0 },
+	{ "riscv", LZMA_FILTER_RISCV, 0 },
 	{ NULL, LZMA_VLI_UNKNOWN, 0 }
 };
 
@@ -468,6 +476,11 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 		stream->opt.dict_size = stream->dictionary_size;
 
 		switch(filter->filter[0].id) {
+		case LZMA_FILTER_RISCV:
+			/* 2-byte-aligned instructions */
+			stream->opt.lp = 1;
+			break;
+
 		case LZMA_FILTER_ARM64:
 			/* 4-byte-aligned instructions */
 			stream->opt.lp = 2;
@@ -533,7 +546,7 @@ static void xz_usage(FILE *stream, int cols)
 	autowrap_print(stream, "\t\tCompress using filter1,filter2,...,filterN "
 		"in turn (in addition to no filter), and choose the best "
 		"compression.  Available filters: x86, arm, armthumb, arm64, "
-		"powerpc, sparc, ia64\n", cols);
+		"powerpc, sparc, ia64, riscv\n", cols);
 	autowrap_print(stream, "\t  -Xdict-size <dict-size>\n", cols);
 	autowrap_print(stream, "\t\tUse <dict-size> as the XZ dictionary size."
 		"  The dictionary size can be specified as a percentage of the "

--- a/squashfs-tools/xz_wrapper_extended.c
+++ b/squashfs-tools/xz_wrapper_extended.c
@@ -107,6 +107,12 @@ static int xz_options(char *argv[], int argc)
 					"filter\n");
 				goto failed;
 			}
+			if(!lzma_filter_encoder_is_supported(bcj[i].id)) {
+				fprintf(stderr, "xz: -Xbcj %s: This filter "
+					"is not supported by the liblzma "
+					"version in use\n", bcj[i].name);
+				goto failed;
+			}
 		}
 
 		return 1;

--- a/squashfs-tools/xz_wrapper_extended.c
+++ b/squashfs-tools/xz_wrapper_extended.c
@@ -565,15 +565,26 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 		stream->opt.dict_size = stream->dictionary_size;
 
 		switch(filter->filter[0].id) {
+		case LZMA_FILTER_ARMTHUMB:
 		case LZMA_FILTER_RISCV:
 			/* 2-byte-aligned instructions */
 			stream->opt.lp = 1;
 			break;
 
+		case LZMA_FILTER_POWERPC:
+		case LZMA_FILTER_ARM:
+		case LZMA_FILTER_SPARC:
 		case LZMA_FILTER_ARM64:
 			/* 4-byte-aligned instructions */
 			stream->opt.lp = 2;
 			stream->opt.lc = 2;
+			break;
+
+		case LZMA_FILTER_IA64:
+			/* 16-byte-aligned instructions */
+			stream->opt.pb = 4;
+			stream->opt.lp = 4;
+			stream->opt.lc = 0;
 			break;
 		}
 

--- a/squashfs-tools/xz_wrapper_extended.c
+++ b/squashfs-tools/xz_wrapper_extended.c
@@ -19,7 +19,7 @@
  * xz_wrapper_extended.c
  *
  * Support for XZ (LZMA2) compression using XZ Utils liblzma
- * http://tukaani.org/xz/
+ * https://tukaani.org/xz/
  *
  * This file supports OpenWrt extended XZ compression options.
  */

--- a/squashfs-tools/xz_wrapper_extended.c
+++ b/squashfs-tools/xz_wrapper_extended.c
@@ -42,6 +42,13 @@
 #define LZMA_FILTER_ARM64 LZMA_VLI_C(0x0A)
 #endif
 
+/*
+ * RISC-V filter was added in liblzma 5.6.0.
+ */
+#ifndef LZMA_FILTER_RISCV
+#define LZMA_FILTER_RISCV LZMA_VLI_C(0x0B)
+#endif
+
 static struct bcj bcj[] = {
 	{ "x86", LZMA_FILTER_X86, 0 },
 	{ "powerpc", LZMA_FILTER_POWERPC, 0 },
@@ -50,6 +57,7 @@ static struct bcj bcj[] = {
 	{ "armthumb", LZMA_FILTER_ARMTHUMB, 0 },
 	{ "sparc", LZMA_FILTER_SPARC, 0 },
 	{ "arm64", LZMA_FILTER_ARM64, 0 },
+	{ "riscv", LZMA_FILTER_RISCV, 0 },
 	{ NULL, LZMA_VLI_UNKNOWN, 0 }
 };
 
@@ -557,6 +565,11 @@ static int xz_compress(void *strm, void *dest, void *src,  int size,
 		stream->opt.dict_size = stream->dictionary_size;
 
 		switch(filter->filter[0].id) {
+		case LZMA_FILTER_RISCV:
+			/* 2-byte-aligned instructions */
+			stream->opt.lp = 1;
+			break;
+
 		case LZMA_FILTER_ARM64:
 			/* 4-byte-aligned instructions */
 			stream->opt.lp = 2;
@@ -631,7 +644,7 @@ static void xz_usage(FILE *stream, int cols)
 	autowrap_print(stream, "\t\tCompress using filter1,filter2,...,filterN "
 		"in turn (in addition to no filter), and choose the best "
 		"compression.  Available filters: x86, arm, armthumb, arm64, "
-		"powerpc, sparc, ia64\n", cols);
+		"powerpc, sparc, ia64, riscv\n", cols);
 	autowrap_print(stream, "\t  -Xdict-size <dict-size>\n", cols);
 	autowrap_print(stream, "\t\tUse <dict-size> as the XZ dictionary size."
 		"  The dictionary size can be specified as a percentage of the "


### PR DESCRIPTION
Add support for ARM64 and RISC-V filters.

Optimize LZMA2 settings for existing filters. It's the last commit. I'm not sure if this change is acceptable as is.

Trivial whitespace fixes and HTTP to HTTPS URL changes are included too.

Feel free to pick the commits you like and tweak them too if you wish. Or, of course, I can edit based on feedback. :-)

@plougher: I sent you an email on 2024-07-31 and a reminder on 2024-08-22. I haven't gotten any replies, so I assume emails are getting lost somewhere. There is no rush as the kernel patches will only be in Linux 6.12 (apparently I have misunderstood something about merge window timing). So if you are busy, don't worry about the emails or this PR. Among a few other things, the first email included things that are related to this PR, so it could be good if you were able to read it before merging these.

Thanks!
