### PR TITLE
Resolve `l` type pseudo links

### DIFF
--- a/squashfs-tools/pseudo.c
+++ b/squashfs-tools/pseudo.c
@@ -525,6 +525,14 @@ static struct pseudo_dev *read_pseudo_def_link(char *orig_def, char *def, char *
 		goto error;
 	}
 
+	char *resolved_linkname = realpath(linkname, NULL);
+	if (resolved_linkname == NULL) {
+		ERROR("Cannot resolve pseudo link file %s because %s\n", linkname, strerror(errno));
+		goto error;
+	}
+	free(linkname);
+	linkname = resolved_linkname;
+
 	dev = malloc(sizeof(struct pseudo_dev));
 	if(dev == NULL)
 		MEM_ERROR();


### PR DESCRIPTION
Resolve `l` type pseudo links before copying them in. 

Closes https://github.com/plougher/squashfs-tools/issues/289

```console
❯ take /tmp/mksquashfs-test
❯ echo hello > hello.txt
❯ ln -s hello.txt hello.link
❯ echo 'hello l hello.link' > pf.txt
❯ mkdir empty
❯ ll
total 12K
drwxrwxr-x 2 lalten lalten 4,0K Okt  9 21:55 empty
lrwxrwxrwx 1 lalten lalten    9 Okt  9 21:55 hello.link -> hello.txt
-rw-rw-r-- 1 lalten lalten    6 Okt  9 21:55 hello.txt
-rw-rw-r-- 1 lalten lalten   19 Okt  9 22:00 pf.txt
❯ ~/squashfs-tools/squashfs-tools/mksquashfs empty img.sqfs -pf pf.txt -exit-on-error -info -all-root -reproducible -mkfs-time 0 -root-time 0 -all-time 0
Parallel mksquashfs: Using 16 processors
Creating 4.0 filesystem on img.sqfs, block size 131072.
hello l 06002 0 36890207 0 1
file /hello, uncompressed size 6 bytes 
squashfs: File inode, file_size 6, start_block 0x0, blocks 0, fragment 0, offset 0, size 6
squashfs: Created inode 0x0, type 2, uid 0, guid 0
squashfs: Directory inode, file_size 28, start_block 0x0, offset 0x0, nlink 2
squashfs: Created inode 0x20, type 1, uid 0, guid 0
squashfs: Directory contents of inode 0x20
squashfs:       Start block 0x0, count 1
squashfs:               name hello, inode offset 0x0, type 2
directory / inode 0x20
squashfs: Writing fragment 0, uncompressed size 6, compressed size 6
squashfs: Inode block @ 0x0, size 31
squashfs: Directory block @ 0x0, size 23
squashfs: write_fragment_table: fragments 1, frag_bytes 16
squashfs: write_fragment_table: fragment 0, start_block 0x60, size 16777222
squashfs: block 0 @ 0xa0, compressed size 18
squashfs: generic_write_table: total uncompressed 16 compressed 26
squashfs: block 0 @ 0xba, compressed size 16
squashfs: generic_write_table: total uncompressed 16 compressed 24
squashfs: write_id_table: ids 1, id_bytes 4
squashfs: write_id_table: id index 0, id 0squashfs: block 0 @ 0xd2, compressed size 6
squashfs: generic_write_table: total uncompressed 4 compressed 14
squashfs: sBlk->inode_table_start 0x66
squashfs: sBlk->directory_table_start 0x87
squashfs: sBlk->fragment_table_start 0xb2
squashfs: sBlk->lookup_table_start 0xca

Exportable Squashfs 4.0 filesystem, gzip compressed, data block size 131072
        compressed data, compressed metadata, compressed fragments,
        compressed xattrs, compressed ids
        duplicates are removed
Filesystem size 0.22 Kbytes (0.00 Mbytes)
        87.84% of uncompressed filesystem size (0.25 Kbytes)
Inode table size 33 bytes (0.03 Kbytes)
        50.00% of uncompressed inode table size (66 bytes)
Directory table size 25 bytes (0.02 Kbytes)
        92.59% of uncompressed directory table size (27 bytes)
Number of duplicate files found 0
Number of inodes 2
Number of files 1
Number of fragments 1
Number of symbolic links 0
Number of device nodes 0
Number of fifo nodes 0
Number of socket nodes 0
Number of directories 1
Number of hard-links 0
Number of ids (unique uids + gids) 1
Number of uids 1
        root (0)
Number of gids 1
        root (0)
❯ unsquashfs img.sqfs
Parallel unsquashfs: Using 16 processors
1 inodes (1 blocks) to write

[==========================================================================|] 1/1 100%

created 1 file
created 1 directory
created 0 symlinks
created 0 devices
created 0 fifos
created 0 sockets
❯ ll squashfs-root
total 4,0K
-rw-rw-r-- 1 lalten lalten 6 Jan  1  1970 hello
❯ cat squashfs-root/hello
hello
```