### PR TITLE
Fix format specifiers

### DIFF
--- a/squashfs-tools/error.h
+++ b/squashfs-tools/error.h
@@ -24,8 +24,10 @@
  * error.h
  */
 
-extern void progressbar_error(char *fmt, ...);
-extern void progressbar_info(char *fmt, ...);
+extern void progressbar_error(char *fmt, ...)
+	__attribute__ ((format (printf, 1, 2)));
+extern void progressbar_info(char *fmt, ...)
+	__attribute__ ((format (printf, 1, 2)));
 
 #ifdef SQUASHFS_TRACE
 #define TRACE(s, args...) \

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -2673,7 +2673,7 @@ static void *writer(void *arg)
 		if(wpos != off) {
 			if(lseek(fd, off, SEEK_SET) == -1) {
 				ERROR("writer: Lseek on destination failed because "
-					"%s, offset=0x%llx\n", strerror(errno), off);
+					"%s, offset=0x%llx\n", strerror(errno), (long long)off);
 				BAD_ERROR("Probably out of space on output "
 					"%s\n", block_device ? "block device" :
 					"filesystem");
@@ -6404,7 +6404,7 @@ FILE *open_info_file(char *filename)
 	res = stat(filename, &buf);
 	if(res == -1) {
 		if(errno != ENOENT)
-			BAD_ERROR("Failed to stat info_file filename \"%s\" because %s\n", strerror(errno));
+			BAD_ERROR("Failed to stat info_file filename \"%s\" because %s\n", filename, strerror(errno));
 
 		file = fopen(filename, "w");
 		if(file == NULL)
@@ -6514,7 +6514,7 @@ static int sqfstar(int argc, char *argv[])
 			}
 			compressor_opt_parsed = 1;
 			if(X_opt_parsed) {
-				ERROR("%s: -comp option should be before any "
+				ERROR("sqfstar: -comp option should be before any "
 					"-X option\n");
 				exit(1);
 			}
@@ -6815,7 +6815,7 @@ static int sqfstar(int argc, char *argv[])
 					!parse_number(argv[i], &percent, 2) ||
 					(percent < 1)) {
 				ERROR("sqfstar: -mem-percent missing or invalid "
-					"percentage: it should be 1 - 75%\n");
+					"percentage: it should be 1 - 75%%\n");
 				sqfstar_option_help(argv[i - 1]);
 			}
 
@@ -7893,7 +7893,7 @@ int main(int argc, char *argv[])
 					!parse_number(argv[i], &percent, 2) ||
 					(percent < 1)) {
 				ERROR("mksquashfs: -mem-percent missing or invalid "
-					"percentage: it should be 1 - 75%\n");
+					"percentage: it should be 1 - 75%%\n");
 				mksquashfs_option_help(argv[i - 1]);
 			}
 

--- a/squashfs-tools/print_pager.h
+++ b/squashfs-tools/print_pager.h
@@ -34,6 +34,7 @@ extern void wait_to_die(pid_t process);
 extern FILE *exec_pager(pid_t *process);
 extern int get_column_width();
 extern void autowrap_print(FILE *stream, char *text, int maxl);
-extern void autowrap_printf(FILE *stream, int maxl, char *fmt, ...);
+extern void autowrap_printf(FILE *stream, int maxl, char *fmt, ...)
+	__attribute__ ((format (printf, 3, 4)));
 extern int check_and_set_pager(char *pager);
 #endif

--- a/squashfs-tools/unsquash-3.c
+++ b/squashfs-tools/unsquash-3.c
@@ -216,7 +216,7 @@ static struct inode *read_inode(unsigned int start_block, unsigned int offset)
 		EXIT_UNSQUASH("File system corrupted - inode number in inode too large (inode_number: %u)\n", header.base.inode_number);
 
 	if(header.base.inode_number == 0)
-		EXIT_UNSQUASH("File system corrupted - inode number zero is invalid\n", header.base.inode_number);
+		EXIT_UNSQUASH("File system corrupted - inode number zero is invalid\n");
 
 	i.mode = lookup_type[header.base.inode_type] | header.base.mode;
 	i.type = header.base.inode_type;

--- a/squashfs-tools/unsquash-4.c
+++ b/squashfs-tools/unsquash-4.c
@@ -158,7 +158,7 @@ static struct inode *read_inode(unsigned int start_block, unsigned int offset)
 		EXIT_UNSQUASH("File system corrupted - inode number in inode too large (inode_number: %u)\n", header.base.inode_number);
 
 	if(header.base.inode_number == 0)
-		EXIT_UNSQUASH("File system corrupted - inode number zero is invalid\n", header.base.inode_number);
+		EXIT_UNSQUASH("File system corrupted - inode number zero is invalid\n");
 
 	i.uid = (uid_t) id_table[header.base.uid];
 	i.gid = (uid_t) id_table[header.base.guid];

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -4023,7 +4023,7 @@ static int parse_cat_options(int argc, char *argv[])
 					!parse_number_percent(argv[i], &percent) ||
 					(percent < 1)) {
 				ERROR("%s: -mem-percent missing or invalid "
-					"percentage: it should be 1 - 75%\n",
+					"percentage: it should be 1 - 75%%\n",
 					 argv[0]);
 				sqfscat_option_help(argv[i - 1]);
 			}
@@ -4324,7 +4324,7 @@ static int parse_options(int argc, char *argv[])
 					!parse_number_percent(argv[i], &percent) ||
 					(percent < 1)) {
 				ERROR("unsquashfs: -mem-percent missing or invalid "
-					"percentage: it should be 1 - 75%\n");
+					"percentage: it should be 1 - 75%%\n");
 				unsquashfs_option_help("-mem-percent");
 			}
 


### PR DESCRIPTION
Some format specifiers did not match given arguments. I have added a compiler attribute to make these violations directly visible in the future.

The already existing violations are fixed with this pull request as well.