### PR TITLE
Check memory allocation results

### DIFF
--- a/squashfs-tools/action.c
+++ b/squashfs-tools/action.c
@@ -754,6 +754,8 @@ static char *_expr_log(char *string, int cmnd)
 	switch(cmnd) {
 	case LOG_ENABLE:
 		expr_msg = malloc(ALLOC_SZ);
+		if(expr_msg == NULL)
+			MEM_ERROR();
 		alloc_size = ALLOC_SZ;
 		cur_size = 0;
 		return expr_msg;

--- a/squashfs-tools/action.c
+++ b/squashfs-tools/action.c
@@ -454,7 +454,10 @@ static struct expr *parse_test(char *name)
 		if (argv == NULL)
 			MEM_ERROR();
 
-		argv[args ++ ] = strdup(string);
+		argv[args] = strdup(string);
+		if (argv[args] == NULL)
+			MEM_ERROR();
+		args ++;
 
 		token = get_token(&string);
 
@@ -625,7 +628,10 @@ int parse_action(char *s, int verbose)
 		if (argv == NULL)
 			MEM_ERROR();
 
-		argv[args ++] = strdup(string);
+		argv[args] = strdup(string);
+		if (argv[args] == NULL)
+			MEM_ERROR();
+		args ++;
 
 		token = get_token(&string);
 
@@ -1027,7 +1033,11 @@ void eval_actions(struct dir_info *root, struct dir_ent *dir_ent)
 
 	action_data.name = dir_ent->name;
 	action_data.pathname = strdup(pathname(dir_ent));
+	if (action_data.pathname == NULL)
+		MEM_ERROR();
 	action_data.subpath = strdup(subpathname(dir_ent));
+	if (action_data.subpath == NULL)
+		MEM_ERROR();
 	action_data.buf = &dir_ent->inode->buf;
 	action_data.depth = dir_ent->our_dir->depth;
 	action_data.dir_ent = dir_ent;
@@ -1061,7 +1071,11 @@ void *eval_frag_actions(struct dir_info *root, struct dir_ent *dir_ent, int tail
 
 	action_data.name = dir_ent->name;
 	action_data.pathname = strdup(pathname(dir_ent));
+	if (action_data.pathname == NULL)
+		MEM_ERROR();
 	action_data.subpath = strdup(subpathname(dir_ent));
+	if (action_data.subpath == NULL)
+		MEM_ERROR();
 	action_data.buf = &dir_ent->inode->buf;
 	action_data.depth = dir_ent->our_dir->depth;
 	action_data.dir_ent = dir_ent;
@@ -1418,7 +1432,11 @@ int eval_empty_actions(struct dir_info *root, struct dir_ent *dir_ent)
 
 	action_data.name = dir_ent->name;
 	action_data.pathname = strdup(pathname(dir_ent));
+	if (action_data.pathname == NULL)
+		MEM_ERROR();
 	action_data.subpath = strdup(subpathname(dir_ent));
+	if (action_data.subpath == NULL)
+		MEM_ERROR();
 	action_data.buf = &dir_ent->inode->buf;
 	action_data.depth = dir_ent->our_dir->depth;
 	action_data.dir_ent = dir_ent;
@@ -1662,7 +1680,11 @@ void eval_move_actions(struct dir_info *root, struct dir_ent *dir_ent)
 
 	action_data.name = dir_ent->name;
 	action_data.pathname = strdup(pathname(dir_ent));
+	if (action_data.pathname == NULL)
+		MEM_ERROR();
 	action_data.subpath = strdup(subpathname(dir_ent));
+	if (action_data.subpath == NULL)
+		MEM_ERROR();
 	action_data.buf = &dir_ent->inode->buf;
 	action_data.depth = dir_ent->our_dir->depth;
 	action_data.dir_ent = dir_ent;
@@ -1755,6 +1777,8 @@ static void move_dir(struct dir_ent *dir_ent)
 	/* update our directory's subpath name */
 	free(dir->subpath);
 	dir->subpath = strdup(subpathname(dir_ent));
+	if (dir->subpath == NULL)
+		MEM_ERROR();
 
 	/* recursively update the subpaths of any sub-directories */
 	for(comp_ent = dir->list; comp_ent; comp_ent = comp_ent->next)
@@ -1814,6 +1838,8 @@ static void move_file(struct move_ent *move_ent)
 		 */
 		if(dir_ent->nonstandard_pathname == NULL) {
 			dir_ent->nonstandard_pathname = strdup(filename);
+			if(dir_ent->nonstandard_pathname == NULL)
+				MEM_ERROR();
 			if(dir_ent->source_name) {
 				free(dir_ent->source_name);
 				dir_ent->source_name = NULL;
@@ -1886,7 +1912,11 @@ int eval_prune_actions(struct dir_info *root, struct dir_ent *dir_ent)
 
 	action_data.name = dir_ent->name;
 	action_data.pathname = strdup(pathname(dir_ent));
+	if (action_data.pathname == NULL)
+		MEM_ERROR();
 	action_data.subpath = strdup(subpathname(dir_ent));
+	if (action_data.subpath == NULL)
+		MEM_ERROR();
 	action_data.buf = &dir_ent->inode->buf;
 	action_data.depth = dir_ent->our_dir->depth;
 	action_data.dir_ent = dir_ent;
@@ -1943,7 +1973,11 @@ static struct xattr_data *eval_xattr_actions (struct action *spec,
 
 	action_data.name = dir_ent->name;
 	action_data.pathname = strdup(pathname(dir_ent));
+	if (action_data.pathname == NULL)
+		MEM_ERROR();
 	action_data.subpath = strdup(subpathname(dir_ent));
+	if (action_data.subpath == NULL)
+		MEM_ERROR();
 	action_data.buf = &dir_ent->inode->buf;
 	action_data.depth = dir_ent->our_dir->depth;
 	action_data.dir_ent = dir_ent;
@@ -2047,7 +2081,11 @@ struct xattr_add *eval_xattr_add_actions(struct dir_info *root,
 
 	action_data.name = dir_ent->name;
 	action_data.pathname = strdup(pathname(dir_ent));
+	if (action_data.pathname == NULL)
+		MEM_ERROR();
 	action_data.subpath = strdup(subpathname(dir_ent));
+	if (action_data.subpath == NULL)
+		MEM_ERROR();
 	action_data.buf = &dir_ent->inode->buf;
 	action_data.depth = dir_ent->our_dir->depth;
 	action_data.dir_ent = dir_ent;
@@ -2360,7 +2398,10 @@ static char *get_start(char *s, int n)
 
 static int subpathname_fn(struct atom *atom, struct action_data *data)
 {
-	char *s = get_start(strdup(data->subpath), count_components(atom->argv[0]));
+	char *path = strdup(data->subpath);
+	if (path == NULL)
+		MEM_ERROR();
+	char *s = get_start(path, count_components(atom->argv[0]));
 	int res = fnmatch(atom->argv[0], s, FNM_PATHNAME|FNM_EXTMATCH);
 
 	free(s);
@@ -2982,7 +3023,11 @@ static int readlink_fn(struct atom *atom, struct action_data *action_data)
 
 	eval_action.name = dir_ent->name;
 	eval_action.pathname = strdup(pathname(dir_ent));
+	if(eval_action.pathname == NULL)
+		MEM_ERROR();
 	eval_action.subpath = strdup(subpathname(dir_ent));
+	if(eval_action.subpath == NULL)
+		MEM_ERROR();
 	eval_action.buf = &dir_ent->inode->buf;
 	eval_action.depth = dir_ent->our_dir->depth;
 	eval_action.dir_ent = dir_ent;
@@ -3084,7 +3129,11 @@ static int eval_fn(struct atom *atom, struct action_data *action_data)
 
 	eval_action.name = dir_ent->name;
 	eval_action.pathname = strdup(pathname(dir_ent));
+	if(eval_action.pathname == NULL)
+		MEM_ERROR();
 	eval_action.subpath = strdup(subpathname(dir_ent));
+	if(eval_action.subpath == NULL)
+		MEM_ERROR();
 	eval_action.buf = &dir_ent->inode->buf;
 	eval_action.depth = dir_ent->our_dir->depth;
 	eval_action.dir_ent = dir_ent;

--- a/squashfs-tools/action.c
+++ b/squashfs-tools/action.c
@@ -1511,6 +1511,7 @@ static char *move_pathname(struct move_ent *move)
 static char *get_comp(char **pathname)
 {
 	char *path = *pathname, *start;
+	char *p;
 
 	while(*path == '/')
 		path ++;
@@ -1523,7 +1524,10 @@ static char *get_comp(char **pathname)
 		path ++;
 
 	*pathname = path;
-	return strndup(start, path - start);
+	p = strndup(start, path - start);
+	if(p == NULL)
+		MEM_ERROR();
+	return p;
 }
 
 

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -4740,10 +4740,14 @@ static char *walk_source(char *source, char **pathname, char **name)
 		source ++;
 
 	*name = strndup(start, source - start);
+	if(*name == NULL)
+		MEM_ERROR();
 
-	if(*pathname == NULL)
+	if(*pathname == NULL) {
 		*pathname = strndup(path, source - path);
-	else {
+		if(*pathname == NULL)
+			MEM_ERROR();
+	} else {
 		char *orig = *pathname;
 		int size = strlen(orig) + (source - path) + 2;
 
@@ -5575,6 +5579,8 @@ static char *get_component(char *target, char **targname)
 		target ++;
 
 	*targname = strndup(start, target - start);
+	if(*targname == NULL)
+		MEM_ERROR();
 
 	while(*target == '/')
 		target ++;

--- a/squashfs-tools/pseudo.c
+++ b/squashfs-tools/pseudo.c
@@ -85,6 +85,8 @@ char *get_element(char *target, char **targname, char **subpathend)
 		target ++;
 
 	*targname = strndup(start, target - start);
+	if(*targname == NULL)
+		MEM_ERROR();
 	*subpathend = target;
 
 	while(*target == '/')
@@ -115,6 +117,8 @@ struct pseudo_entry *pseudo_search(struct pseudo *pseudo, char *targname,
 
 	ent->name = targname;
 	ent->pathname = strndup(alltarget, subpathend - alltarget);
+	if(ent->pathname == NULL)
+		MEM_ERROR();
 	ent->dev = NULL;
 	ent->pseudo = NULL;
 	ent->xattr = NULL;

--- a/squashfs-tools/pseudo.c
+++ b/squashfs-tools/pseudo.c
@@ -576,6 +576,8 @@ static struct pseudo_dev *read_pseudo_def_link(char *orig_def, char *def, char *
 	dev->type = 'l';
 	dev->pseudo_type = PSEUDO_FILE_OTHER;
 	dev->linkname = strdup(linkname);
+	if(dev->linkname == NULL)
+		MEM_ERROR();
 
 	free(linkname);
 	return dev;
@@ -883,6 +885,8 @@ static struct pseudo_dev *read_pseudo_def_extended(char type, char *orig_def,
 				MEM_ERROR();
 
 			(*file)->filename = strdup(pseudo_file);
+			if ((*file)->filename == NULL)
+				MEM_ERROR();
 			(*file)->fd = -1;
 		}
 
@@ -898,11 +902,16 @@ static struct pseudo_dev *read_pseudo_def_extended(char type, char *orig_def,
 	} else if(type == 'F') {
 		dev->pseudo_type = PSEUDO_FILE_PROCESS;
 		dev->command = strdup(command);
+		if(dev->command == NULL)
+			MEM_ERROR();
 	} else
 		dev->pseudo_type = PSEUDO_FILE_OTHER;
 
-	if(type == 'S')
+	if(type == 'S') {
 		dev->symlink = strdup(symlink);
+		if(dev->symlink == NULL)
+			MEM_ERROR();
+	}
 
 	return dev;
 }
@@ -1105,11 +1114,16 @@ static struct pseudo_dev *read_pseudo_def_original(char type, char *orig_def, ch
 	if(type == 'f') {
 		dev->pseudo_type = PSEUDO_FILE_PROCESS;
 		dev->command = strdup(command);
+		if(dev->command == NULL)
+			MEM_ERROR();
 	} else
 		dev->pseudo_type = PSEUDO_FILE_OTHER;
 
-	if(type == 's')
+	if(type == 's') {
 		dev->symlink = strdup(symlink);
+		if(dev->symlink == NULL)
+			MEM_ERROR();
+	}
 
 	return dev;
 }

--- a/squashfs-tools/symbolic_mode.c
+++ b/squashfs-tools/symbolic_mode.c
@@ -262,7 +262,10 @@ int parse_mode(char *source, struct mode_data **data)
 
 			argv = new;
 
-			argv[args ++] = strndup(first, cur_ptr - first);
+			argv[args] = strndup(first, cur_ptr - first);
+			if(argv[args] == NULL)
+			       MEM_ERROR();
+			args ++;
 		}
 
 		if(*cur_ptr == ',')

--- a/squashfs-tools/symbolic_mode.h
+++ b/squashfs-tools/symbolic_mode.h
@@ -26,6 +26,8 @@
 #define SYNTAX_ERR(S, ARGS...) { \
 	if(source) { \
 		char *src = strdup(source); \
+		if(src == NULL) \
+			MEM_ERROR(); \
 		src[cur_ptr - source] = '\0'; \
 		fprintf(stderr, "Failed to parse action \"%s\"\n", source); \
 		fprintf(stderr, "Syntax error: "S, ##ARGS); \

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -228,6 +228,8 @@ static char *get_component(char *target, char **targname)
 		target ++;
 
 	*targname = strndup(start, target - start);
+	if(*targname == NULL)
+		MEM_ERROR();
 
 	while(*target == '/')
 		target ++;
@@ -1344,6 +1346,8 @@ again:
 	} else if (file->pathname == NULL) {
 		filename = skip_components(header.name, 100, &size);
 		file->pathname = strndup(filename, size);
+		if(file->pathname == NULL)
+			MEM_ERROR();
 	}
 
 	/* Ignore empty filenames */
@@ -1387,8 +1391,11 @@ again:
 	res = -1;
 	if(file->uname)
 		user = file->uname;
-	else
+	else {
 		user = strndup(header.user, 32);
+		if(user == NULL)
+			MEM_ERROR();
+	}
 
 	if(strlen(user)) {
 		struct passwd *pwuid = getpwnam(user);
@@ -1418,8 +1425,11 @@ again:
 	res = -1;
 	if(file->gname)
 		group = file->gname;
-	else
+	else {
 		group = strndup(header.group, 32);
+		if(group == NULL)
+			MEM_ERROR();
+	}
 
 	if(strlen(group)) {
 		struct group *grgid = getgrnam(group);
@@ -1464,8 +1474,11 @@ again:
 		/* Permissions on symbolic links are always rwxrwxrwx */
 		file->buf.st_mode = 0777 | S_IFLNK;
 
-		if(file->link == FALSE)
+		if(file->link == FALSE) {
 			file->link = strndup(header.link, 100);
+			if(file->link == NULL)
+				MEM_ERROR();
+		}
 	}
 
 	/* Handle hard links */
@@ -1484,6 +1497,8 @@ again:
 		} else {
 			filename = skip_components(header.link, 100, &size);
 			file->link = strndup(filename, size);
+			if(file->link == NULL)
+				MEM_ERROR();
 		}
 	}
 

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -805,15 +805,23 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 				goto failed;
 			file->buf.st_mtime = number;
 			file->have_mtime = TRUE;
-		} else if(strcmp(keyword, "uname") == 0)
+		} else if(strcmp(keyword, "uname") == 0) {
 			file->uname = strdup(value);
-		else if(strcmp(keyword, "gname") == 0)
+			if(file->uname == NULL)
+				MEM_ERROR();
+		} else if(strcmp(keyword, "gname") == 0) {
 			file->gname = strdup(value);
-		else if(strcmp(keyword, "path") == 0)
+			if(file->gname == NULL)
+				MEM_ERROR();
+		} else if(strcmp(keyword, "path") == 0) {
 			file->pathname = strdup(skip_components(value, vsize, NULL));
-		else if(strcmp(keyword, "linkpath") == 0)
+			if(file->pathname == NULL)
+				MEM_ERROR();
+		} else if(strcmp(keyword, "linkpath") == 0) {
 			file->link = strdup(value);
-		else if(strcmp(keyword, "GNU.sparse.major") == 0) {
+			if(file->link == NULL)
+				MEM_ERROR();
+		} else if(strcmp(keyword, "GNU.sparse.major") == 0) {
 			res = sscanf(value, "%lld %n", &number, &bytes);
 			if(res < 1 || value[bytes] != '\0')
 				goto failed;
@@ -828,9 +836,11 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 			if(res < 1 || value[bytes] != '\0')
 				goto failed;
 			realsize = number;
-		} else if(strcmp(keyword, "GNU.sparse.name") == 0)
+		} else if(strcmp(keyword, "GNU.sparse.name") == 0) {
 			name = strdup(value);
-		else if(strcmp(keyword, "GNU.sparse.size") == 0) {
+			if(name == NULL)
+				MEM_ERROR();
+		} else if(strcmp(keyword, "GNU.sparse.size") == 0) {
 			res = sscanf(value, "%lld %n", &number, &bytes);
 			if(res < 1 || value[bytes] != '\0')
 				goto failed;
@@ -1136,14 +1146,26 @@ failed:
 static void copy_tar_header(struct tar_file *dest, struct tar_file *source)
 {
 	memcpy(dest, source, sizeof(struct tar_file));
-	if(source->pathname)
+	if(source->pathname) {
 		dest->pathname = strdup(source->pathname);
-	if(source->link)
+		if(dest->pathname == NULL)
+			MEM_ERROR();
+	}
+	if(source->link) {
 		dest->link = strdup(source->link);
-	if(source->uname)
+		if(dest->link == NULL)
+			MEM_ERROR();
+	}
+	if(source->uname) {
 		dest->uname = strdup(source->uname);
-	if(source->gname)
+		if(dest->uname == NULL)
+			MEM_ERROR();
+	}
+	if(source->gname) {
 		dest->gname = strdup(source->gname);
+		if(dest->gname == NULL)
+			MEM_ERROR();
+	}
 }
 
 
@@ -1455,6 +1477,8 @@ again:
 				char *old = file->link;
 
 				file->link = strdup(link);
+				if(file->link == NULL)
+					MEM_ERROR();
 				free(old);
 			}
 		} else {

--- a/squashfs-tools/unsquash-1.c
+++ b/squashfs-tools/unsquash-1.c
@@ -389,6 +389,8 @@ static struct dir *squashfs_opendir(unsigned int block_start, unsigned int offse
 				MEM_ERROR();
 
 			ent->name = strdup(dire->name);
+			if(ent->name == NULL)
+				MEM_ERROR();
 			ent->start_block = dirh.start_block;
 			ent->offset = dire->offset;
 			ent->type = dire->type;

--- a/squashfs-tools/unsquash-2.c
+++ b/squashfs-tools/unsquash-2.c
@@ -483,6 +483,8 @@ static struct dir *squashfs_opendir(unsigned int block_start, unsigned int offse
 				MEM_ERROR();
 
 			ent->name = strdup(dire->name);
+			if(ent->name == NULL)
+				MEM_ERROR();
 			ent->start_block = dirh.start_block;
 			ent->offset = dire->offset;
 			ent->type = dire->type;

--- a/squashfs-tools/unsquash-3.c
+++ b/squashfs-tools/unsquash-3.c
@@ -505,6 +505,8 @@ static struct dir *squashfs_opendir(unsigned int block_start, unsigned int offse
 				MEM_ERROR();
 
 			ent->name = strdup(dire->name);
+			if(ent->name == NULL)
+				MEM_ERROR();
 			ent->start_block = dirh.start_block;
 			ent->offset = dire->offset;
 			ent->type = dire->type;

--- a/squashfs-tools/unsquash-4.c
+++ b/squashfs-tools/unsquash-4.c
@@ -444,6 +444,8 @@ static struct dir *squashfs_opendir(unsigned int block_start, unsigned int offse
 				MEM_ERROR();
 
 			ent->name = strdup(dire->name);
+			if(ent->name == NULL)
+				MEM_ERROR();
 			ent->start_block = dirh.start_block;
 			ent->offset = dire->offset;
 			ent->type = dire->type;

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -1462,6 +1462,8 @@ static char *get_component(char *target, char **targname)
 		target ++;
 
 	*targname = strndup(start, target - start);
+	if(*targname == NULL)
+		MEM_ERROR();
 
 	while(*target == '/')
 		target ++;

--- a/squashfs-tools/xattr.c
+++ b/squashfs-tools/xattr.c
@@ -120,6 +120,8 @@ static int xattr_get_type(char *name)
 static void xattr_copy_prefix(struct xattr_list *xattr, int t, char *name)
 {
 	xattr->full_name = strdup(name);
+	if(xattr->full_name == NULL)
+		MEM_ERROR();
 	xattr->name = xattr->full_name + strlen(prefix_table[t].prefix);
 	xattr->size = strlen(xattr->name);
 }

--- a/squashfs-tools/xattr.c
+++ b/squashfs-tools/xattr.c
@@ -1021,6 +1021,8 @@ struct xattr_add *xattr_parse(char *str, char *pre, char *option)
 		MEM_ERROR();
 
 	entry->name = strndup(str, value++ - str);
+	if(entry->name == NULL)
+		MEM_ERROR();
 	entry->type = xattr_get_type(entry->name);
 
 	if(entry->type == -1) {


### PR DESCRIPTION
The checks are already in place for calloc, malloc, realloc. One malloc check was missing.

Add checks for strdup and strndup just to be safe.