### PR TITLE
Makefile: Add easy support for sanitizers

### DIFF
--- a/squashfs-tools/Makefile
+++ b/squashfs-tools/Makefile
@@ -154,6 +154,15 @@ REPRODUCIBLE_DEFAULT = 1
 USE_PREBUILT_MANPAGES=n
 
 ###############################################
+#         Executables with sanitizers         #
+###############################################
+#
+# Select whether you want to use sanitizers for executables.
+# Sanitizers can be selected through SANITIZERS
+USE_SANITIZERS = 0
+SANITIZERS = address,undefined
+
+###############################################
 #              INSTALL PATHS                  #
 ###############################################
 #
@@ -203,6 +212,8 @@ XATTR_OS_SUPPORT ?= 1
 XATTR_DEFAULT ?= 1
 REPRODUCIBLE_DEFAULT ?= 1
 USE_PREBUILT_MANPAGES ?= 1
+USE_SANITIZERS ?= 0
+SANITIZERS ?= address,undefined
 INSTALL_PREFIX ?= /usr/local
 INSTALL_DIR ?= $(INSTALL_PREFIX)/bin
 INSTALL_MANPAGES_DIR ?= $(INSTALL_PREFIX)/man/man1
@@ -344,6 +355,14 @@ endif
 
 ifeq ($(REPRODUCIBLE_DEFAULT),1)
 CFLAGS += -DREPRODUCIBLE_DEFAULT
+endif
+
+ifeq ($(USE_SANITIZERS),1)
+ifndef SANITIZERS
+$(error "USE_SANITIZERS requires SANITIZERS to be also defined")
+endif
+CFLAGS += -fsanitize=$(SANITIZERS)
+LDFLAGS += -fsanitize=$(SANITIZERS)
 endif
 
 #

--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -435,7 +435,7 @@ int add_overflow(int a, int b)
 }
 
 
-int shift_overflow(int a, int shift)
+static int shift_overflow(int a, int shift)
 {
 	return (INT_MAX >> shift) < a;
 }
@@ -447,7 +447,7 @@ int multiply_overflow(int a, int multiplier)
 }
 
 
-int multiply_overflowll(long long a, int multiplier)
+static int multiply_overflowll(long long a, int multiplier)
 {
 	return (LLONG_MAX / multiplier) < a;
 }
@@ -457,13 +457,13 @@ int multiply_overflowll(long long a, int multiplier)
 			+ (((char *)A) - data_cache)))
 
 
-inline void set_pos(long long value)
+static inline void set_pos(long long value)
 {
 	pos = value;
 }
 
 
-inline long long get_pos(void)
+static inline long long get_pos(void)
 {
 	return pos;
 }
@@ -478,7 +478,7 @@ long long get_and_inc_pos(long long value)
 }
 
 
-inline int reset_pos(void)
+static inline int reset_pos(void)
 {
 	if(marked_pos == 0)
 		BAD_ERROR("BUG: Saved write position is empty!\n");
@@ -491,7 +491,7 @@ inline int reset_pos(void)
 }
 
 
-inline void unmark_pos()
+static inline void unmark_pos()
 {
 	if(marked_pos == 0)
 		BAD_ERROR("BUG: Saved write position should not be empty!\n");
@@ -500,7 +500,7 @@ inline void unmark_pos()
 }
 
 
-inline void mark_pos()
+static inline void mark_pos()
 {
 	if(marked_pos != 0)
 		BAD_ERROR("BUG: Saved write position should be empty!\n");
@@ -509,7 +509,7 @@ inline void mark_pos()
 }
 
 
-inline long long get_marked_pos(void)
+static inline long long get_marked_pos(void)
 {
 	if(marked_pos == 0)
 		BAD_ERROR("BUG: Saved write position is empty!\n");
@@ -520,14 +520,14 @@ inline long long get_marked_pos(void)
 }
 
 
-inline long long set_write_buffer(struct file_buffer *buffer, int size)
+static inline long long set_write_buffer(struct file_buffer *buffer, int size)
 {
 	buffer->block = get_and_inc_pos(size);
 	return buffer->block;
 }
 
 
-inline void put_write_buffer_hash(struct file_buffer *buffer, int put)
+static inline void put_write_buffer_hash(struct file_buffer *buffer, int put)
 {
 	if(marked_pos == 0)
 		BAD_ERROR("BUG: Saved write position should not be empty!\n");


### PR DESCRIPTION
I have to make local adjustments in the code to use ASAN and UBSAN. I think that it's a compiler issue, but both commits should be beneficial for squashfs-tools regardless.

Adding ASAN and UBSAN is simple now:
```
$ make USE_SANITIZERS=1
```