### PR TITLE
Support negative levels for zstd compression

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -376,7 +376,8 @@ Compressors available and compressor specific options:
 		etc.
 	zstd
 	  -Xcompression-level <compression-level>
-		<compression-level> should be 1 .. 22 (default 15)
+		<compression-level> should be -131072 .. -1 or 1 .. 22 (default 15)
+		Negative compression levels correspond to the zstd --fast option.
 
 Source1 source2 ... are the source directories/files containing the
 files/directories that will form the squashfs filesystem.  If a single
@@ -502,7 +503,8 @@ Compressors available and compressor specific options:
 		etc.
 	zstd
 	  -Xcompression-level <compression-level>
-		<compression-level> should be 1 .. 22 (default 15)
+		<compression-level> should be -131072 .. -1 or 1 .. 22 (default 15)
+		Negative compression levels correspond to the zstd --fast option.
 
 If the compressor offers compression specific options (all the compressors now
 have compression specific options except the deprecated lzma1 compressor)

--- a/manpages/mksquashfs.1
+++ b/manpages/mksquashfs.1
@@ -460,7 +460,7 @@ Use DICT\-SIZE as the XZ dictionary size.  The dictionary size can be specified 
 .SS "zstd:"
 .TP
 \fB\-Xcompression\-level\fR COMPRESSION\-LEVEL
-COMPRESSION\-LEVEL should be 1 .. 22 (default 15)
+COMPRESSION\-LEVEL should be \fB\-131072\fR .. \fB\-1\fR or 1 .. 22 (default 15) Negative compression levels correspond to the zstd \fB\-\-fast\fR option.
 .SH ENVIRONMENT
 .TP
 SQFS_CMDLINE

--- a/manpages/sqfstar.1
+++ b/manpages/sqfstar.1
@@ -378,7 +378,7 @@ Use DICT\-SIZE as the XZ dictionary size.  The dictionary size can be specified 
 .SS "zstd:"
 .TP
 \fB\-Xcompression\-level\fR COMPRESSION\-LEVEL
-COMPRESSION\-LEVEL should be 1 .. 22 (default 15)
+COMPRESSION\-LEVEL should be \fB\-131072\fR .. \fB\-1\fR or 1 .. 22 (default 15) Negative compression levels correspond to the zstd \fB\-\-fast\fR option.
 .SH ENVIRONMENT
 .TP
 SQFS_CMDLINE

--- a/squashfs-tools/zstd_wrapper.c
+++ b/squashfs-tools/zstd_wrapper.c
@@ -52,12 +52,25 @@ static int zstd_options(char *argv[], int argc)
 			fprintf(stderr, "zstd: -Xcompression-level missing "
 				"compression level\n");
 			fprintf(stderr, "zstd: -Xcompression-level it should "
-				"be 1 <= n <= %d\n", ZSTD_maxCLevel());
+				"be %d <= n <= -1 or 1 <= n <= %d\n",
+				ZSTD_minCLevel(), ZSTD_maxCLevel());
 			goto failed;
 		}
 
 		compression_level = atoi(argv[1]);
-		if (compression_level < 1 ||
+		if (compression_level == 0) {
+			fprintf(stderr, "zstd: -Xcompression-level invalid, it "
+				"should be %d <= n <= -1 or 1 <= n <= %d\n",
+				ZSTD_minCLevel(), ZSTD_maxCLevel());
+			goto failed;
+		}
+		if (compression_level < 0 &&
+		    compression_level < ZSTD_minCLevel()) {
+			fprintf(stderr, "zstd: -Xcompression-level invalid, it "
+				"should be %d <= n <= -1\n", ZSTD_minCLevel());
+			goto failed;
+		}
+		if (compression_level > 0 &&
 		    compression_level > ZSTD_maxCLevel()) {
 			fprintf(stderr, "zstd: -Xcompression-level invalid, it "
 				"should be 1 <= n <= %d\n", ZSTD_maxCLevel());
@@ -133,7 +146,8 @@ static int zstd_extract_options(int block_size, void *buffer, int size)
 
 	SQUASHFS_INSWAP_COMP_OPTS(comp_opts);
 
-	if (comp_opts->compression_level < 1 ||
+	if (comp_opts->compression_level == 0 ||
+	    comp_opts->compression_level < ZSTD_minCLevel() ||
 	    comp_opts->compression_level > ZSTD_maxCLevel()) {
 		fprintf(stderr, "zstd: bad compression level in compression "
 			"options structure\n");
@@ -161,7 +175,8 @@ static void zstd_display_options(void *buffer, int size)
 
 	SQUASHFS_INSWAP_COMP_OPTS(comp_opts);
 
-	if (comp_opts->compression_level < 1 ||
+	if (comp_opts->compression_level == 0 ||
+	    comp_opts->compression_level < ZSTD_minCLevel() ||
 	    comp_opts->compression_level > ZSTD_maxCLevel()) {
 		fprintf(stderr, "zstd: bad compression level in compression "
 			"options structure\n");
@@ -236,8 +251,9 @@ static int zstd_uncompress(void *dest, void *src, int size, int outsize,
 static void zstd_usage(FILE *stream, int cols)
 {
 	autowrap_print(stream, "\t  -Xcompression-level <compression-level>\n", cols);
-	autowrap_printf(stream, cols, "\t\t<compression-level> should be 1 .. %d (default %d)\n",
-				ZSTD_maxCLevel(), ZSTD_DEFAULT_COMPRESSION_LEVEL);
+	autowrap_printf(stream, cols, "\t\t<compression-level> should be %d .. -1 or 1 .. %d (default %d)\n"
+			        "Negative compression levels correspond to the zstd --fast option.\n",
+				ZSTD_minCLevel(), ZSTD_maxCLevel(), ZSTD_DEFAULT_COMPRESSION_LEVEL);
 }
 
 


### PR DESCRIPTION
These levels correspond to the --fast option of the zstd program,
and offers better compression speed for worse compression rate.

Closes #303