### PR TITLE
Need to include unistd.h before using pathconf

### DIFF
--- a/squashfs-tools/mksquashfs.h
+++ b/squashfs-tools/mksquashfs.h
@@ -25,6 +25,7 @@
  *
  */
 #include <pthread.h>
+#include <unistd.h>
 
 struct dir_info {
 	char			*pathname;


### PR DESCRIPTION
I got a compile error when trying to build squashfs-tools on macOS:

```
./mksquashfs.h:217:13: error: call to undeclared function 'pathconf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  217 |         path_max = pathconf(".", _PC_PATH_MAX);
      |                    ^
./mksquashfs.h:217:27: error: use of undeclared identifier '_PC_PATH_MAX'
  217 |         path_max = pathconf(".", _PC_PATH_MAX);
      |                                  ^
```

I think clang might be a bit stricter than gcc, so it wanted an extra include. 