### PR TITLE
sqfstar: improve tar parser stability

### DIFF
--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -976,7 +976,7 @@ static struct file_map *read_sparse_headers(struct tar_file *file, struct short_
 
 	/* If we've read two or less entries, then we expect the isextended
 	 * entry to be FALSE */
-	isextended = read_number(&short_header->isextended, 1);
+	isextended = short_header->isextended;
 	if(i < 3 && isextended) {
 		ERROR("Invalid sparse header\n");
 		goto failed;
@@ -1015,7 +1015,7 @@ static struct file_map *read_sparse_headers(struct tar_file *file, struct short_
 
 		/* If we've read less than 21 entries, then we expect the isextended
 		 * entry to be FALSE */
-		isextended = read_number(&long_header.isextended, 1);
+		isextended = long_header.isextended;
 		if(i < (map_entries + 21) && isextended) {
 			ERROR("Invalid sparse header\n");
 			goto failed;

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -24,6 +24,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <dirent.h>
@@ -102,6 +103,20 @@ static long long read_number(char *s, int size)
 		return read_octal(s, size);
 }
 
+static long long read_pax_number(char *s, int *bytes)
+{
+	long long res = 0;
+
+	*bytes = 0;
+	for(; *s >= '0' && *s <= '9'; s++) {
+		int digit = *s - '0';
+		if(res > LLONG_MAX / 10 || res * 10 > LLONG_MAX - digit)
+			return -1;
+		res = (res * 10) + digit;
+		*bytes += 1;
+	}
+	return res;
+}
 
 static long long read_decimal(char *s, int maxsize, int *bytes)
 {
@@ -686,20 +701,20 @@ static char *skip_components(char *filename, int size, int *sizep)
 
 static int read_sparse_value(struct tar_file *file, char *value, int map_entries)
 {
-	int bytes, res, i = 0;
+	int bytes, i = 0;
 	long long number;
 
 	while(1) {
-		res = sscanf(value, "%lld %n", &number, &bytes);
-		if(res < 1 || value[bytes] != ',')
+		number = read_pax_number(value, &bytes);
+		if(number == -1 || value[bytes] != ',')
 			goto failed;
 
 		file->map[i].offset = number;
 
 		value += bytes + 1;
 
-		res = sscanf(value, "%lld %n", &number, &bytes);
-		if(res < 1 || (value[bytes] != ',' && value[bytes] != '\0'))
+		number = read_pax_number(value, &bytes);
+		if(number == -1 || (value[bytes] != ',' && value[bytes] != '\0'))
 			goto failed;
 
 		file->map[i++].number = number;
@@ -721,8 +736,8 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 {
 	long long size = (st_size + 511) & ~511;
 	char *data, *ptr, *end, *keyword, *value;
-	int res, length, bytes, vsize;
-	long long number;
+	int res, bytes, vsize;
+	long long length, number;
 	long long major = -1, minor = -1, realsize = -1;
 	int old_gnu_pax = FALSE, old_gnu_ver = -1;
 	int map_entries = 0, cur_entry = 0;
@@ -749,8 +764,8 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 		 * where <length> is the full length, including the
 		 * <length> field and newline
 		 */
-		res = sscanf(ptr, "%d%n", &length, &bytes);
-		if(res < 1 || length <= bytes || length > st_size)
+		length = read_pax_number(ptr, &bytes);
+		if(length == -1 || length <= bytes || length > st_size)
 			goto failed;
 
 		length -= bytes;
@@ -790,28 +805,34 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 
 		/* Evaluate keyword */
 		if(strcmp(keyword, "size") == 0) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			file->buf.st_size = number;
 			file->have_size = TRUE;
 		} else if(strcmp(keyword, "uid") == 0) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			file->buf.st_uid = number;
+			if(file->buf.st_uid != number)
+				goto failed;
 			file->have_uid = TRUE;
 		} else if(strcmp(keyword, "gid") == 0) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			file->buf.st_gid = number;
+			if(file->buf.st_gid != number)
+				goto failed;
 			file->have_gid = TRUE;
 		} else if(strcmp(keyword, "mtime") == 0) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '.')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '.')
 				goto failed;
 			file->buf.st_mtime = number;
+			if(file->buf.st_mtime != number)
+				goto failed;
 			file->have_mtime = TRUE;
 		} else if(strcmp(keyword, "uname") == 0)
 			file->uname = STRDUP(value);
@@ -822,46 +843,46 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 		else if(strcmp(keyword, "linkpath") == 0)
 			file->link = STRDUP(value);
 		else if(strcmp(keyword, "GNU.sparse.major") == 0) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			major = number;
 		} else if(strcmp(keyword, "GNU.sparse.minor") == 0) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			minor = number;
 		} else if(strcmp(keyword, "GNU.sparse.realsize") == 0) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			realsize = number;
 		} else if(strcmp(keyword, "GNU.sparse.name") == 0)
 			name = STRDUP(value);
 		else if(strcmp(keyword, "GNU.sparse.size") == 0) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			realsize = number;
 			old_gnu_pax = 1;
 		} else if(strcmp(keyword, "GNU.sparse.numblocks") == 0 && old_gnu_pax == 1) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0' || number > SIZE_MAX / sizeof(struct file_map))
 				goto failed;
 			file->map = MALLOC(number * sizeof(struct file_map));
 			map_entries = number;
 			cur_entry = 0;
 			old_gnu_pax = 2;
 		} else if(strcmp(keyword, "GNU.sparse.offset") == 0 && old_gnu_pax == 2 && old_gnu_ver != 1) {
-			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			number = read_pax_number(value, &bytes);
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			if(cur_entry < map_entries)
 				file->map[cur_entry].offset = number;
 			old_gnu_ver = 0;
 		} else if(strcmp(keyword, "GNU.sparse.numbytes") == 0 && old_gnu_pax == 2 && old_gnu_ver != 1) {
 			res = sscanf(value, "%lld %n", &number, &bytes);
-			if(res < 1 || value[bytes] != '\0')
+			if(number == -1 || value[bytes] != '\0')
 				goto failed;
 			if(cur_entry < map_entries)
 				file->map[cur_entry++].number = number;

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -751,8 +751,11 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 		length -= bytes;
 		ptr += bytes;
 
-		/* Skip whitespace */
-		for(; length && *ptr == ' '; length--, ptr++);
+		/* Skip mandatory whitespace */
+		if(*ptr != ' ')
+			goto failed;
+		ptr++;
+		length --;
 
 		/* Store and parse keyword */
 		for(keyword = ptr; length && *ptr != '='; length--, ptr++);

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -728,7 +728,7 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 	int map_entries = 0, cur_entry = 0;
 	char *name = NULL;
 
-	data = MALLOC(size);
+	data = MALLOC(size + 1);
 	res = read_bytes(STDIN_FILENO, data, size);
 	if(res < size) {
 		if(res != -1)
@@ -736,6 +736,7 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 		free(data);
 		return FALSE;
 	}
+	data[size] = '\0';
 
 	for(ptr = data, end = data + st_size; ptr < end;) {
 		/*

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -1321,6 +1321,10 @@ again:
 			goto failed;
 		}
 		file->buf.st_mtime = res;
+		if(file->buf.st_mtime != res) {
+			ERROR("Failed to read file mtime from tar header\n");
+			goto failed;
+		}
 	}
 
 	/* Read mode and file type */

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -728,6 +728,11 @@ static int read_pax_header(struct tar_file *file, long long st_size)
 	int map_entries = 0, cur_entry = 0;
 	char *name = NULL;
 
+	if(size > INT_MAX) {
+		ERROR("The pax header of tarfile is too large\n");
+		return FALSE;
+	}
+
 	data = MALLOC(size + 1);
 	res = read_bytes(STDIN_FILENO, data, size);
 	if(res < size) {

--- a/squashfs-tools/tar.c
+++ b/squashfs-tools/tar.c
@@ -21,6 +21,7 @@
  * tar.c
  */
 
+#include <limits.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -83,8 +84,11 @@ static long long read_binary(char *src, int size)
 	unsigned char *s = (unsigned char *) src;
 	long long res = 0;
 
-	for(; size; s++, size --)
+	for(; size; s++, size --) {
+		if (res > LLONG_MAX >> 8)
+			return -1;
 		res = (res << 8) + *s;
+	}
 
 	return res;
 }


### PR DESCRIPTION
These commits fix different issues in sqfstar's tar parser and partially
depend on each other to mitigate the discussed issues fully:

1. Simple undefined C behaviour

Signed integer overflows are undefined behaviour and should be avoided.
From a C perspective, I do not care too much about them, but they can
lead to crashes later on in the code, e.g. because sqfstar does not
expect to encouter actually negative numbers for sizes later on.

Commits:

- sqfstar: prevent tarfile size overflows
- sqfstar: prevent st_rdev signed integer overflows
- sqfstar: terminate pax extended header string

Proof of Concepts:

This crashes sqfstar because of negative sizes:
```
cat > poc.tar.zst.b64 << EOF
KLUv/WQABe0BAPh1d3UAMDAwNjQ0IAAwgP/+MCAyMgAgMAB1c3RhcgAwCwCQ4H4AGsCGAL9BMgCX
JdW6AGKcxpUNoD09ASJ2tBTh
EOF
base64 -d poc.tar.zst.b64 | zstd -d > poc.tar
sqfstar poc.sqfs < poc.tar
```

The crash occurs because the parsed number -2 leads to a read of 0 bytes
and a fragment added into the fragment processor. The processor itself
tries to create a checksum and eventually reads past the end of
allocated memory.

This triggers a signed integer overflow (compile with UBSAN):
```
cat > poc.tar.zst.b64 << EOF
KLUv/WQABd0BABQCdXd1ADAwMDY0NCAAMCA2MTA1ACAzAHVzdGFyADAwAID/CiAwg3qk+DAKtpiX
DmDKJ3nBFsN1euJEqAiTSA==
EOF
base64 -d poc.tar.zst.b64 | zstd -d > poc.tar
sqfstar poc.sqfs < poc.tar
```

This triggers an out ouf boundary read:
```
cat > poc.tar.zst.b64 << EOF
KLUv/WQAEc0BAAQCdXd1ADAwMDA2NDQAMDE2NjA3ACB4AHVzdGFyADAwADAIAPwHvpgD6gBc4hc3
bnK30gMYTk+ACCQC//M=
EOF
base64 -d poc.tar.zst.b64 | zstd -d > poc.tar
sqfstar poc.sqfs < poc.tar
```

It is not covered by ASAN and hard to see in reality as a crash.
In fact, it took an OpenBSD system with its guard pages to prove that
out of boundary access can occur.

2. Compatibility with other tar implementations

The sqfstar code has some unique traits in it which allows different
views on the same tar archive with different tools, e.g. GNU tar,
libarchive, docker (Go), and so on. It is possible to create a tar
archive which sneaks in special information into a squash filesystem
which otherwise is not detected. Sylab's singularity utilizes sqfstar
for conversions from OCI containers to sqfs. By making sqfstar behave
more like the other tar parsers and stay closer to the POSIX standard,
such attacks will be harder to be performed.

Commits:

- sqfstar: check isextended on bit level
- sqfstar: expect exactly one blank in pax header

Proof of Concepts:

This file can be parsed by GNU tar and libarchive, not by sqfstar:
```
cat > poc.tar.zst.b64 << EOF
KLUv/aQACAIA9AQA8oUQE8AlHWCT9gcB6gaZZJKJw6t6RAbkTaS73tnP38rIbPuqxbJWezIRXTiX
ZhiDjBAkMAjKAMS4p3I4bd2KY58kpwxKMaBwmEopwxhwgyZJDmj7GYdFd5iEOF9pPOuwa9lnahAD
uHhrKKgrUlSqVKtcrwReWVk5KC5rlSmD8gDRanvxwQys7dc+LoT3D0xPB5yHCdwkUZiVE9s9wRYD
QAAAcLdDWw==
EOF
base64 -d poc.tar.zst.b64 | zstd -d > poc.tar
sqfstar poc.sqfs < poc.tar
```

This file sneaks in a different link into sqfs from tar:
```
cat > poc.tar.zst.b64 << EOF
KLUv/WQADQ0FACJGFRpwiXONJDQBG6zXin+fK31U962UNAD+z76XAsd2l/N8NRJVlVkS6gLKGTFy
nXWR7CqCAksIw2FhTtG/V2JN83NO1SPmfx8H8v9uTkPNUklSgycRECAbIAADMSko6AGkkA+D+n5x
iAEHZTQAAri5lNbij4QBmg12LHgA2W8C7ChCwDAOo+qZzVIf4GGtU8N8URKQU/a1XjgHBcMJ01sC
o2bKaw==
EOF
base64 -d poc.tar.zst.b64 | zstd -d > poc.tar
sqfstar poc.sqfs < poc.tar
```
```
tar -tvf poc.tar
unsquashfs -d poc poc.sqfs
ls -l poc
```

You can see that the poc.sqfs contains a link to a different target than
the tar file implies with GNU tar or libarchive's bsdtar.

3. Attacker controlled out of boundary write

The sparse map parser allows a targeted out of boundary write with
attacker controlled data. Together with heap spraying due to leaking
memory if pax keywords are supplied multiple times, this might allow
an attacker to perform elevated attacks. Together with number 2, this
can be targeted specifically against sqfstar without triggering issues
with other tar implementations.

Commit:

- sqfstar: use stricter pax number checks

Proof of Concept (compile with ASAN):

```
cat > poc.tar.zst.b64 << EOF
KLUv/WQAA7UDACLGFRtwa3NAk2AzqkPP0YNBwH1NI5KSytRA+l9dngx3Dvhi2IJ4VCWaAbWm0zHB
9K9NGBiKwtIWmedLeSAWUbZhzCKEgQAdz76GNbbdAZ1SSRXevky17WuOFgoApTj14Cnuxcm1OaAO
wCXeicNLQSsIgOH0BIi3SxxV
EOF
base64 -d poc.tar.zst.b64 | zstd -d > poc.tar
sqfstar poc.sqfs < poc.tar
```

This allows an attacker to write multiples of 16 bytes beyond a multiple
of 16 bytes of allocated memory.

4. Tighter checks

Some values might overflow system data types, e.g. times. These commits
are merely cleanups.

Commits:

- sqfstar: check st_mtime assignment
- sqfstar: make 2 GB pax header limit more obvious
