### PR TITLE
Add rsyncable option to gzip and zstd compression

### DIFF
--- a/squashfs-tools/gzip_wrapper.h
+++ b/squashfs-tools/gzip_wrapper.h
@@ -34,6 +34,7 @@ extern unsigned int inswap_le32(unsigned int);
 	(s)->compression_level = inswap_le32((s)->compression_level); \
 	(s)->window_size = inswap_le16((s)->window_size); \
 	(s)->strategy = inswap_le16((s)->strategy); \
+	(s)->rsyncable = inswap_le32((s)->rsyncable); \
 }
 #else
 #define SQUASHFS_INSWAP_COMP_OPTS(s)
@@ -47,6 +48,7 @@ struct gzip_comp_opts {
 	int compression_level;
 	short window_size;
 	short strategy;
+	int rsyncable;
 };
 
 struct strategy {

--- a/squashfs-tools/zstd_wrapper.h
+++ b/squashfs-tools/zstd_wrapper.h
@@ -28,6 +28,7 @@ extern unsigned int inswap_le32(unsigned int);
 
 #define SQUASHFS_INSWAP_COMP_OPTS(s) { \
 	(s)->compression_level = inswap_le32((s)->compression_level); \
+	(s)->rsyncable = inswap_le32((s)->rsyncable); \
 }
 #else
 #define SQUASHFS_INSWAP_COMP_OPTS(s)
@@ -38,5 +39,6 @@ extern unsigned int inswap_le32(unsigned int);
 
 struct zstd_comp_opts {
 	int compression_level;
+	int rsyncable;
 };
 #endif


### PR DESCRIPTION
Currently this requires linking a patched or static version of the
libraries, where support for "rsyncable" compression has been added.

For zstd specifically, this also requires defining a special macro
`-DZSTD_STATIC_LINKING_ONLY=1`, before #include <zstd.h> (in flags).

Assuming that the static libraries have been installed under /opt:

```
EXTRA_CFLAGS="-I/opt/zlib/include -DZSTD_STATIC_LINKING_ONLY=1 -I/opt/zstd/include" EXTRA_LDFLAGS="-L/opt/zlib/lib -L/opt/zstd/lib" make
```

----

The original patch for zlib seems lost, but resurrected it from [deltarpm](https://github.com/rpm-software-management/deltarpm/tree/master/zlib-1.2.2.f-rsyncable)
`https://svn.uhulinux.hu/packages/dev/zlib/patches/02-rsync.patch`

For zstd it is now included by default (since version 1.3.8), but it still a
"experimental parameter" and thus _requires_ static linking like above.

The idea behind rsyncable is to add some "synchronization points",
using a rolling hash instead of a fixed size, to help with delta transfer.

The output format is compatible, but the extra hash makes it slower...
Thus it is **not** supported for lz4, and not recommended for fast zstd*.

\* compression levels below 6 or so, i.e. normally used with 9 or 15

> zstd.h says: "NOTE: Rsyncable mode will limit the maximum compression speed to approximately 400 MB/s. [...]"

---

"The rsync algorithm": https://rsync.samba.org/tech_report/

`gzip -9 --rsyncable`

The pigz implementation uses a [faster hash](https://github.com/madler/pigz/blob/v2.8/pigz.c#L483), than the original gzip.

`zstd -9 --rsyncable`
