### PR TITLE
thread: add the missing pthread.h header

### DIFF
--- a/squashfs-tools/thread.h
+++ b/squashfs-tools/thread.h
@@ -22,6 +22,7 @@
  *
  * thread.h
  */
+#include <pthread.h>
 
 #define TRUE 1
 #define FALSE 0


### PR DESCRIPTION
Fix build error on macos:

```
In file included from mksquashfs_help.c:35:
./thread.h:46:39: error: unknown type name 'pthread_mutex_t'; did you mean 'pthread_attr_t'?
   46 | extern void wait_thread_idle(int tid, pthread_mutex_t *mutex);
      |                                       ^~~~~~~~~~~~~~~
      |                                       pthread_attr_t
```

I noticed this issue when adding squashfs 4.7 to the OpenWrt. If you have a better fix, please ignore this PR. Ref: https://github.com/openwrt/openwrt/actions/runs/15440483743/job/43456872621