### PR TITLE
Don't inline quoted_bs_char

### DIFF
--- a/squashfs-tools/print_pager.c
+++ b/squashfs-tools/print_pager.c
@@ -77,7 +77,7 @@ static char *get_base(char *pathname)
 }
 
 
-inline int quoted_bs_char(char cur)
+int quoted_bs_char(char cur)
 {
 	/*
 	 * Within double quoted strings Bash allows the characters ‘$’, ‘`’,


### PR DESCRIPTION
Fixes https://github.com/plougher/squashfs-tools/issues/322

I would say this function is not performance critical so inlining is not essential here.