### PR TITLE
Makefile: auto-detect Homebrew paths on macOS

### DIFF
--- a/squashfs-tools/Makefile
+++ b/squashfs-tools/Makefile
@@ -249,6 +249,15 @@ endif
 #
 INCLUDEDIR = -I.
 
+# Homebrew support for macOS
+ifeq ($(shell uname -s),Darwin)
+BREW_PREFIX := $(shell brew --prefix 2>/dev/null)
+ifneq ($(BREW_PREFIX),)
+INCLUDEDIR += -I$(BREW_PREFIX)/include
+EXTRA_LDFLAGS += -L$(BREW_PREFIX)/lib
+endif
+endif
+
 MKSQUASHFS_OBJS = mksquashfs.o read_fs.o action.o swap.o pseudo.o compressor.o \
 	sort.o progressbar.o info.o restore.o process_fragments.o \
 	caches-queues-lists.o reader.o tar.o date.o memory.o mksquashfs_help.o \


### PR DESCRIPTION
## Summary

- On macOS, compression library headers (lzo, lz4, xz, zstd) installed via Homebrew are not in the default system include path, so `make` fails out of the box
- Auto-detect the Homebrew prefix on Darwin and add its include/lib paths to `INCLUDEDIR` and `EXTRA_LDFLAGS`
- Handles both Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local`) Homebrew installations
- No-op on Linux (guarded by `uname -s` check) and does not interfere with the existing `*_DIR` per-library path mechanism

## Test plan

- [x] `make clean && make` succeeds on macOS (Apple Silicon) without manual CFLAGS/LDFLAGS
- [x] `mksquashfs -version` prints version info
- [x] Round-trip test: create a squashfs image with `mksquashfs` and list with `unsquashfs -l`
- [ ] Verify no-op on Linux (the `ifeq ($(shell uname -s),Darwin)` guard ensures this)