### PR TITLE
fix(mksquashfs): use st_atimespec on macOS

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -3372,7 +3372,9 @@ static struct inode_info *lookup_inode4(struct stat *buf, struct pseudo_dev *pse
 		 *   lazytime or relatime and the file has been created or
 		 *   modified since the last access.
 		 */
-#ifdef st_atime
+#ifdef __APPLE__
+		memset(&buf->st_atimespec, 0, sizeof(buf->st_atimespec));
+#elif defined(st_atime)
 		memset(&buf->st_atim, 0, sizeof(buf->st_atim));
 #else
 		memset(&buf->st_atime, 0, sizeof(buf->st_atime));


### PR DESCRIPTION
Fix macOS build failure in `mksquashfs.c` when `struct stat` does not provide `st_atim`.

Change:
- use `st_atimespec` on macOS
- keep existing `st_atim`/`st_atime` paths for other platforms

Ref: https://github.com/Homebrew/homebrew-core/pull/270087
