### PR TITLE
Makeifile: add support for DESTDIR

### DIFF
--- a/squashfs-tools/Makefile
+++ b/squashfs-tools/Makefile
@@ -593,9 +593,9 @@ clean:
 
 .PHONY: install
 install: mksquashfs unsquashfs
-	mkdir -p $(INSTALL_DIR)
-	cp mksquashfs $(INSTALL_DIR)
-	cp unsquashfs $(INSTALL_DIR)
-	ln -fs unsquashfs $(INSTALL_DIR)/sqfscat
-	ln -fs mksquashfs $(INSTALL_DIR)/sqfstar
-	generate-manpages/install-manpages.sh $(shell pwd)/.. "$(INSTALL_MANPAGES_DIR)" "$(USE_PREBUILT_MANPAGES)"
+	mkdir -p $(DESTDIR)$(INSTALL_DIR)
+	cp mksquashfs $(DESTDIR)$(INSTALL_DIR)
+	cp unsquashfs $(DESTDIR)$(INSTALL_DIR)
+	ln -fs unsquashfs $(DESTDIR)$(INSTALL_DIR)/sqfscat
+	ln -fs mksquashfs $(DESTDIR)$(INSTALL_DIR)/sqfstar
+	generate-manpages/install-manpages.sh $(shell pwd)/.. "$(DESTDIR)$(INSTALL_MANPAGES_DIR)" "$(USE_PREBUILT_MANPAGES)"


### PR DESCRIPTION
DESTDIR is an established GNU standard to be able to install into a staging dir while keeping PREFIX intact. it's supported by literally every buildsystem on the planet, including backwards ones like CMake.

https://www.gnu.org/prep/standards/html_node/DESTDIR.html