### PR TITLE
Initialize mode_data fields for octal mode arguments

### DIFF
--- a/squashfs-tools/symbolic_mode.c
+++ b/squashfs-tools/symbolic_mode.c
@@ -65,6 +65,8 @@ int parse_octal_mode_args(char *source, char *cur_ptr, int args, char **argv,
 	mode_data = MALLOC(sizeof(struct mode_data));
 	mode_data->operation = SYMBOLIC_MODE_OCT;
 	mode_data->mode = mode;
+	mode_data->mask = 0;
+	mode_data->X = 0;
 	mode_data->next = NULL;
 	*data = mode_data;
 


### PR DESCRIPTION
parse_octal_mode_args() allocates struct mode_data for octal mode arguments but only initializes operation, mode and next.

mode_execute() reads mode_data->X before switching on operation, so octal mode entries can read an uninitialized X field, and may also read mask if X happens to be non-zero.

Initialize mask and X for octal mode entries.