### PR TITLE
mksquashfs: tolerate ftruncate() failing with EOPNOTSUPP/ENOTSUP

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -550,6 +550,30 @@ static inline void put_write_buffer_hash(struct file_buffer *buffer)
 }
 
 
+/*
+ * Truncate the output file to length, discarding any bytes past the end of the
+ * filesystem. Some filesystems do not implement ftruncate() and fail with
+ * EOPNOTSUPP/ENOTSUP; treat that as non-fatal. The bytes_used field in the
+ * super block is authoritative and readers ignore anything beyond it, so
+ * leaving the trailing bytes in place still yields a valid filesystem.
+ */
+static void truncate_filesystem(int fd, long long length, char *filename)
+{
+	if(ftruncate(fd, length) != 0) {
+		if(errno == EOPNOTSUPP || errno == ENOTSUP)
+			ERROR("Warning: could not truncate %s because %s. Leaving "
+				"trailing bytes in place; the filesystem is still valid "
+				"(bytes_used in the super block is authoritative)\n",
+				filename ? filename : "output filesystem",
+				strerror(errno));
+		else
+			BAD_ERROR("Failed to truncate %s because %s\n",
+				filename ? filename : "output filesystem",
+				strerror(errno));
+	}
+}
+
+
 void restorefs()
 {
 	int i, res;
@@ -582,12 +606,8 @@ void restorefs()
 	restore_xattrs();
 	write_filesystem_tables(&sBlk);
 
-	if(!block_device) {
-		int res = ftruncate(fd, get_dpos());
-		if(res != 0)
-			BAD_ERROR("Failed to truncate dest file because %s\n",
-				strerror(errno));
-	}
+	if(!block_device)
+		truncate_filesystem(fd, get_dpos(), NULL);
 
 	if(!nopad && (i = get_dpos() & (4096 - 1))) {
 		char temp[4096] = {0};
@@ -6741,9 +6761,7 @@ static void fix_file(char *filename)
 	if(res == -1)
 		BAD_ERROR("Failed to write file \"%s\"\n", filename);
 
-	res = ftruncate(fd, offset);
-	if(res == -1)
-		BAD_ERROR("Failed to truncate file \"%s\" because %s\n", filename, strerror(errno));
+	truncate_filesystem(fd, offset, filename);
 }
 
 
@@ -7694,12 +7712,8 @@ static int sqfstar(int argc, char *argv[])
 
 	progressbar_finish();
 
-	if(!block_device && !streaming) {
-		res = ftruncate(fd, start_offset + get_dpos());
-		if(res != 0)
-			BAD_ERROR("Failed to truncate dest file because %s\n",
-				strerror(errno));
-	}
+	if(!block_device && !streaming)
+		truncate_filesystem(fd, start_offset + get_dpos(), NULL);
 
 	if(!nopad && (i = get_dpos() & (4096 - 1))) {
 		char temp[4096] = {0};
@@ -9186,12 +9200,8 @@ int main(int argc, char *argv[])
 
 	progressbar_finish();
 
-	if(!block_device && !streaming) {
-		res = ftruncate(fd, start_offset + get_dpos());
-		if(res != 0)
-			BAD_ERROR("Failed to truncate dest file because %s\n",
-				strerror(errno));
-	}
+	if(!block_device && !streaming)
+		truncate_filesystem(fd, start_offset + get_dpos(), NULL);
 
 	if(!nopad && (i = get_dpos() & (4096 - 1))) {
 		char temp[4096] = {0};


### PR DESCRIPTION
Some filesystems do not implement ftruncate() and fail it with EOPNOTSUPP or ENOTSUP (for example certain FUSE and network filesystems). mksquashfs finalizes its output by calling ftruncate() to discard any bytes past the end of the filesystem, and treats any failure as fatal. As a result, writing an image onto such a filesystem -- or running "-fix" over a "-stream" output that lives on one -- aborts with "Failed to truncate ... Operation not supported", even though the image itself is complete.

Route the four ftruncate() call sites (restorefs, fix_file, sqfstar and mksquashfs) through a small truncate_filesystem() helper that downgrades EOPNOTSUPP/ENOTSUP to a warning and leaves the trailing bytes in place. This remains correct: the super block's bytes_used field records the true filesystem length and readers ignore anything beyond it, so an image whose backing file was not truncated is still valid and mountable. Any other errno is still fatal.